### PR TITLE
RenderPartial and ConstraintToHttpMethods

### DIFF
--- a/src/FubuMVC.Core/Registration/Routes/IRouteDefinition.cs
+++ b/src/FubuMVC.Core/Registration/Routes/IRouteDefinition.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Web.Routing;
+using FubuMVC.Core.Registration.Conventions;
 
 namespace FubuMVC.Core.Registration.Routes
 {
@@ -19,5 +20,18 @@ namespace FubuMVC.Core.Registration.Routes
         void Prepend(string prefix);
 
         void RootUrlAt(string baseUrl);
+    }
+
+    public static class RouteDefinitionExtensions
+    {
+        public static void ConstrainToHttpMethods(this IRouteDefinition routeDef, params string[] methods)
+        {
+            if(methods.Length == 0)
+            {
+                return;
+            }
+
+            routeDef.AddRouteConstraint(RouteConstraintPolicy.HTTP_METHOD_CONSTRAINT, new HttpMethodConstraint(methods));
+        }
     }
 }

--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Registration\Querying\ChainResolverTester.cs" />
     <Compile Include="Registration\RouteInputTester.cs" />
     <Compile Include="Registration\system_policy_for_authorization.cs" />
+    <Compile Include="Routing\RouteDefinitionExtensionsTester.cs" />
     <Compile Include="Runtime\BasicSessionTester.cs" />
     <Compile Include="Security\AllowRoleTester.cs" />
     <Compile Include="Security\AuthorizationBehaviorTester.cs" />

--- a/src/FubuMVC.Tests/Routing/RouteDefinitionExtensionsTester.cs
+++ b/src/FubuMVC.Tests/Routing/RouteDefinitionExtensionsTester.cs
@@ -1,0 +1,38 @@
+using System.Web.Routing;
+using FubuMVC.Core.Registration.Conventions;
+using FubuMVC.Core.Registration.Routes;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace FubuMVC.Tests.Routing
+{
+    [TestFixture]
+    public class RouteDefinitionExtensionsTester
+    {
+        private IRouteDefinition _routeDefinition;
+        private SpecificationExtensions.CapturingConstraint _argsToAddConstraint;
+
+        [SetUp]
+        public void Setup()
+        {
+            _routeDefinition = MockRepository.GenerateMock<IRouteDefinition>();
+            _argsToAddConstraint = _routeDefinition.CaptureArgumentsFor(r => r.AddRouteConstraint(null, null));
+        }
+
+        [Test]
+        public void should_add_an_HttpMethodConstraint_to_the_route_definition_for_the_specified_methods()
+        {
+            _routeDefinition.ConstrainToHttpMethods("GET", "POST");
+
+            _argsToAddConstraint
+                .First<string>()
+                .ShouldEqual(RouteConstraintPolicy.HTTP_METHOD_CONSTRAINT);
+
+            _argsToAddConstraint
+                .Second<IRouteConstraint>()
+                .ShouldBeOfType<HttpMethodConstraint>()
+                .AllowedMethods
+                .ShouldHaveTheSameElementsAs("GET", "POST");
+        }
+    }
+}

--- a/src/FubuMVC.UI/PartialExpressionExtensions.cs
+++ b/src/FubuMVC.UI/PartialExpressionExtensions.cs
@@ -129,6 +129,21 @@ namespace FubuMVC.UI
                     viewPage.Model);
         }
 
+        /// <summary>
+        /// Renders a partial view for the view model
+        /// </summary>
+        /// <typeparam name="TViewModel">The type of the view model</typeparam>
+        /// <param name="viewPage"></param>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        public static RenderPartialExpression<TViewModel> RenderPartialFor<TViewModel>(
+            this IFubuPage viewPage, TViewModel model) where TViewModel : class
+        {
+            var renderer = viewPage.Get<IPartialRenderer>();
+            return
+                new RenderPartialExpression<TViewModel>(model, viewPage, renderer, viewPage.Tags<TViewModel>(), viewPage.Get<IEndpointService>()).For(
+                    model);
+        }
 
 
 


### PR DESCRIPTION
Added RenderPartialFor overload typed off of IFubuPage instead of IFubuPage<TViewModel> to allow the model to be passed in directly rather than being derived off the view.

Added extension method for IRouteDefinition. Convenience method to constraint to http methods so that you can easily do it manually in a url policy (especially in cases where you're building up actioncalls via an actionsource).
