### PR TITLE
Spark Action Filter now excludes continuations

### DIFF
--- a/src/Spark.Web.FubuMVC.Tests/Registration/SampleEndpoint.cs
+++ b/src/Spark.Web.FubuMVC.Tests/Registration/SampleEndpoint.cs
@@ -1,3 +1,5 @@
+using FubuMVC.Core.Continuations;
+
 namespace Spark.Web.FubuMVC.Tests.Registration
 {
     public class SampleEndpoint
@@ -5,6 +7,11 @@ namespace Spark.Web.FubuMVC.Tests.Registration
         public SampleOutput Get(SampleInput input)
         {
             return new SampleOutput();
+        }
+
+        public FubuContinuation Post()
+        {
+            return FubuContinuation.RedirectTo(new SampleInput());
         }
     }
 }

--- a/src/Spark.Web.FubuMVC.Tests/Registration/when_applying_action_and_view_filter.cs
+++ b/src/Spark.Web.FubuMVC.Tests/Registration/when_applying_action_and_view_filter.cs
@@ -31,6 +31,16 @@ namespace Spark.Web.FubuMVC.Tests.Registration
         }
 
         [Test]
+        public void should_return_empty_collection_when_action_call_returns_a_fubu_continuation()
+        {
+            var call = ActionCall.For<SampleEndpoint>(e => e.Post());
+
+            ClassUnderTest
+                .Apply(call, _views)
+                .ShouldHaveCount(0);
+        }
+
+        [Test]
         public void should_return_empty_collection_when_resolver_has_no_matching_policies()
         {
             MockFor<ISparkPolicyResolver>()

--- a/src/Spark.Web.FubuMVC/Registration/ActionAndViewMatchedBySparkViewDescriptors.cs
+++ b/src/Spark.Web.FubuMVC/Registration/ActionAndViewMatchedBySparkViewDescriptors.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FubuCore;
+using FubuMVC.Core.Continuations;
 using FubuMVC.Core.Registration.Nodes;
 using FubuMVC.Core.View;
 using Spark.Web.FubuMVC.ViewCreation;
@@ -18,7 +19,7 @@ namespace Spark.Web.FubuMVC.Registration
 
         public IEnumerable<IViewToken> Apply(ActionCall call, ViewBag views)
         {
-            if(!_policyResolver.HasMatchFor(call))
+            if(call.OutputType() == typeof(FubuContinuation) || !_policyResolver.HasMatchFor(call))
             {
                 return new IViewToken[0];
             }


### PR DESCRIPTION
Given the nature of view token matching in WebForms, any action call returning a FubuContinuation doesn't have a matching token (unless of course someone creates a view whose model is a continuation, but that would be weird). 

I ran diagnostics after applying some spark policies and realized that my policies allowed view tokens to be matched on a continuation and it was a little confusing. I figured we should filter these out to avoid any confusion in the future.
