### PR TITLE
Textarea should be input element on HtmlTag.IsInputElement()

### DIFF
--- a/src/HtmlTags.Testing/HtmlTagTester.cs
+++ b/src/HtmlTags.Testing/HtmlTagTester.cs
@@ -55,6 +55,7 @@ namespace HtmlTags.Testing
             tag.IsInputElement().ShouldBeFalse();
             tag.TagName("input").IsInputElement().ShouldBeTrue();
             tag.TagName("select").IsInputElement().ShouldBeTrue();
+            tag.TagName("textarea").IsInputElement().ShouldBeTrue();
         }
 
         [Test]

--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -393,7 +393,7 @@ namespace HtmlTags
 
         public bool IsInputElement()
         {
-            return _tag == "input" || _tag == "select";
+            return _tag == "input" || _tag == "select" || _tag == "textarea";
         }
 
         public void ReplaceChildren(params HtmlTag[] tags)


### PR DESCRIPTION
We ran into this at work when trying to use a custom Editor builder convention in HtmlConventionRegistry.  Thought I would send this up to the official codebase for consideration.  Thanks.
