### PR TITLE
Fix UrlRegistry.UrlFor(ActionCall) bug

### DIFF
--- a/src/FubuMVC.Core/Continuations/ContinuationHandler.cs
+++ b/src/FubuMVC.Core/Continuations/ContinuationHandler.cs
@@ -40,7 +40,7 @@ namespace FubuMVC.Core.Continuations
 
         public void RedirectToCall(ActionCall call)
         {
-            string url = _registry.UrlFor(call);
+            string url = _registry.UrlFor(call.HandlerType, call.Method);
             _writer.RedirectToUrl(url);
         }
 

--- a/src/FubuMVC.Tests/Continuations/ContinuationHandlerTester.cs
+++ b/src/FubuMVC.Tests/Continuations/ContinuationHandlerTester.cs
@@ -111,7 +111,7 @@ namespace FubuMVC.Tests.Continuations
             theUrl = "some/path/1";
             call = ActionCall.For<ControllerTarget>(x => x.ZeroInOneOut());
 
-            MockFor<IUrlRegistry>().Expect(x => x.UrlFor(call)).Return(theUrl);
+            MockFor<IUrlRegistry>().Expect(x => x.UrlFor(call.HandlerType, call.Method)).Return(theUrl);
 
             ProcessContinuation(FubuContinuation.RedirectTo<ControllerTarget>(x => x.ZeroInOneOut()));
         }


### PR DESCRIPTION
The context of this bug and its fix can be found in this Google Groups discussion thread: http://groups.google.com/group/fubumvc-devel/browse_thread/thread/a251f5d5ffe66e4e

This is on behalf of Bob Pace, who attempted to send the patch in the discussion thread in a format that can be imported by the "git am" command. The reason he didn't do a pull request is because he has his fork tied up with another pull request around collection bindings. So I tried the patch import and it failed, so I manually applied the small changes to my repo and am sending the pull request via my repo. I was with Bob when we found the bug and verified the fix.

Thanks in advance. Hope this helps. Let me know if you have further questions concerning the bug or its fix.
