### PR TITLE
Emptymaster

### DIFF
--- a/src/Spark.Web.FubuMVC/ViewLocation/FubuDescriptorBuilder.cs
+++ b/src/Spark.Web.FubuMVC/ViewLocation/FubuDescriptorBuilder.cs
@@ -67,7 +67,7 @@ namespace Spark.Web.FubuMVC.ViewLocation
                     return null;
                 }
             }
-            else if (buildDescriptorParams.FindDefaultMaster && string.IsNullOrEmpty(TrailingUseMasterName(descriptor)))
+            else if (buildDescriptorParams.FindDefaultMaster && TrailingUseMasterName(descriptor) == null)
             {
                 LocatePotentialTemplate(
                     PotentialDefaultMasterLocations(buildDescriptorParams.AcionName,


### PR DESCRIPTION
This fixes the issue of a master page always being used even when the page has &lt;use master="" /&gt;
