### PR TITLE
Spark Packaging

### DIFF
--- a/src/FubuMVC.HelloSpark/Global.asax.cs
+++ b/src/FubuMVC.HelloSpark/Global.asax.cs
@@ -1,12 +1,12 @@
-﻿using Spark.Web.FubuMVC.Registration;
+﻿using FubuMVC.Core;
+using Spark.Web.FubuMVC.Registration;
 using StructureMap;
-using Spark.Web.FubuMVC;
 
 namespace FubuMVC.HelloSpark
 {
     public class Global : SparkStructureMapApplication
     {
-        public override SparkFubuRegistry GetMyRegistry()
+        public override FubuRegistry GetMyRegistry()
         {
             return ObjectFactory.Container.GetInstance<HelloSparkRegistry>();
         }


### PR DESCRIPTION
The SparkStructureMapApplication was using old logic that didn't load packages. I solved this by making it inherit from FubuStructureMapApplication.

Deploying our packages as _Assembly.Name.zip_, the application's SparkFubuRegistry also needed to be configured as follows:

```
Applies.ToAllPackageAssemblies();
AddViewFolder("~/bin/fubu-packages");

SparkPolicies
    .AttachViewsBy(call => call.HandlerType.Name.EndsWith("Controller"),
                   call =>
                    {
                        var name = call.HandlerType.Assembly.GetName().Name;
                        return string.Format("{0}/WebContent/views/{1}", name, call.HandlerType.Name.RemoveSuffix("Controller"));
                    },
                   call => call.Method.Name);
```
