### PR TITLE
Tweak to UsageGraph in Fubu Command line tools

### DIFF
--- a/src/FubuCore/CommandLine/UsageGraph.cs
+++ b/src/FubuCore/CommandLine/UsageGraph.cs
@@ -157,7 +157,8 @@ namespace FubuCore.CommandLine
                 writeMultipleUsages();
             }
 
-            writeArguments();
+            if(Arguments.Any())
+                writeArguments();
 
 
             if (!Flags.Any()) return;


### PR DESCRIPTION
I put a simple fix in so that the Help Command and usage output does not crash when their are no arguments on the command input.
