### PR TITLE
SparkView.SetModel(object model) now implemented

### DIFF
--- a/src/Spark.Web.FubuMVC/ViewCreation/SparkView.cs
+++ b/src/Spark.Web.FubuMVC/ViewCreation/SparkView.cs
@@ -125,7 +125,7 @@ namespace Spark.Web.FubuMVC.ViewCreation
         }
         public void SetModel(object model)
         {
-            throw new NotImplementedException();
+            Model = (TModel)model;
         }
     }
 }


### PR DESCRIPTION
Found an overload of SetModel in the SparkView generic class that throws a NotImplementedException.  Turns out we wanted to call that method overload, so here is a very simple implementation of what it appears that method was designed to do.
