### PR TITLE
Htmltags reference fix

### DIFF
--- a/src/FubuMVC.Core/FubuMVC.Core.csproj
+++ b/src/FubuMVC.Core/FubuMVC.Core.csproj
@@ -36,10 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="HtmlTags">
-      <HintPath>..\..\lib\htmltags\HtmlTags.dll</HintPath>
-    </Reference>
-    <Reference Include="HtmlTags, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>C:\git\fubumvc\lib\htmltags\4.0\HtmlTags.dll</HintPath>
+      <HintPath>..\..\lib\htmltags\4.0\HtmlTags.dll</HintPath>
     </Reference>
     <Reference Include="Ionic.Zip">
       <HintPath>..\..\lib\DotNetZip\Ionic.Zip.dll</HintPath>


### PR DESCRIPTION
Fixes references to the HtmlTags dll in the FubuMVC.Core.csproj
