### PR TITLE
Create new Spark.Web.FubuMVC NuGet package

### DIFF
--- a/packaging/nuget/spark.web.fubumvc.nuspec
+++ b/packaging/nuget/spark.web.fubumvc.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Spark.Web.FubuMVC</id>
+    <version>0.4.0.1</version>
+    <authors>Chad Myers, Jeremy D. Miller, Joshua Flanagan</authors>
+    <owners>Joshua Flanagan</owners>
+    <licenseUrl>https://github.com/DarthFubuMVC/fubumvc/raw/master/license.txt</licenseUrl>
+    <projectUrl>http://fubumvc.com</projectUrl>
+    <iconUrl>https://github.com/DarthFubuMVC/fubumvc/raw/master/doc/logo/FubuMVC_Logo_package_icon.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Spark support for FubuMVC, a compositional, convention-based framework for complex web applications</description>
+    <tags>web framework mvc</tags>
+    <dependencies>
+      <dependency id="FubuMVC" version="0.4.0.1" />
+      <dependency id="Spark" version="1.1" />
+    </dependencies>
+  </metadata>
+  <files>
+	<file src="..\..\build\Spark.Web.FubuMVC.*" target="lib" />
+  </files>
+</package>

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -145,4 +145,5 @@ end
 desc "Build the nuget package"
 task :nuget do
 	sh "lib/nuget.exe pack packaging/nuget/fubumvc.nuspec -o artifacts -Version #{getBuildNumber}"
+	sh "lib/nuget.exe pack packaging/nuget/spark.web.fubumvc.nuspec -o artifacts -Version #{getBuildNumber}"
 end


### PR DESCRIPTION
I'm fairly certain this is not merge ready, but hopefully it is least a start. I'm just starting to look at using FubuMVC + Spark, and wanted to use the NuGet package (via OpenWrap, but that's just details) and noticed that the Spark piece was not included in the package. I would imagine it would make sense to package this separately (using Spark.Web.Mvc3 NuGet package as an example) so I created a separate .nuspec file for this.

I haven't had a chance to actually _test_ the generate .nupkg, but the rakefile does at least successfully build it... Thoughts?
