### PR TITLE
Debug report fix

### DIFF
--- a/src/FubuMVC.Core/Diagnostics/DebugReport.cs
+++ b/src/FubuMVC.Core/Diagnostics/DebugReport.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Web;
 using FubuMVC.Core.Behaviors;
 
@@ -32,7 +33,7 @@ namespace FubuMVC.Core.Diagnostics
                 {
                     Url = context.Request.Url.PathAndQuery;
                     NameValueCollection formData = context.Request.Form;
-                    formData.AllKeys.Each(key =>
+                    formData.AllKeys.Where(x => x != null).Each(key =>
                     {
                         FormData.Add(key, formData[key]);
                     });


### PR DESCRIPTION
When posting json data with diagnostics turned on we found it leaves a null entry in the keys and was blowing up in DebugReport, this fix worked around the issue for us any feedback on it?
