### PR TITLE
added support to supply your own type of ActionCall in behavior matcher

### DIFF
--- a/src/FubuMVC.Core/FubuRegistry.cs
+++ b/src/FubuMVC.Core/FubuRegistry.cs
@@ -14,7 +14,7 @@ namespace FubuMVC.Core
     public partial class FubuRegistry
     {
         private readonly ActionSourceMatcher _actionSourceMatcher = new ActionSourceMatcher();
-        private readonly BehaviorMatcher _behaviorMatcher = new BehaviorMatcher();
+        private readonly BehaviorMatcher _behaviorMatcher;
 
         private readonly List<IConfigurationAction> _conventions = new List<IConfigurationAction>();
         private readonly List<IConfigurationAction> _explicits = new List<IConfigurationAction>();
@@ -26,9 +26,11 @@ namespace FubuMVC.Core
         private readonly TypePool _types = new TypePool(FindTheCallingAssembly());
         private readonly ViewAttacher _viewAttacher;
         private IConfigurationObserver _observer;
+        private Func<Type, MethodInfo, ActionCall> _actionCallProvider = (type, methodInfo) => new ActionCall(type, methodInfo);
 
         public FubuRegistry()
         {
+            _behaviorMatcher = new BehaviorMatcher((type, methodInfo) => _actionCallProvider(type, methodInfo));
             _observer = new NulloConfigurationObserver();
             _viewAttacher = new ViewAttacher(_types);
 
@@ -39,6 +41,11 @@ namespace FubuMVC.Core
         public FubuRegistry(Action<FubuRegistry> configure) : this()
         {
             configure(this);
+        }
+
+        public void ActionCallProvider(Func<Type, MethodInfo, ActionCall> actionCallProvider)
+        {
+            _actionCallProvider = actionCallProvider;
         }
 
         public virtual string Name

--- a/src/FubuMVC.Core/Registration/Conventions/BehaviorMatcher.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/BehaviorMatcher.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using FubuCore.Util;
@@ -11,12 +10,14 @@ namespace FubuMVC.Core.Registration.Conventions
     // TODO:  Blow up if there are no filters of any sort
     public class BehaviorMatcher
     {
+        private readonly Func<Type, MethodInfo, ActionCall> _actionCallProvider;
         private readonly CompositeFilter<ActionCall> _methodFilters = new CompositeFilter<ActionCall>();
         private readonly CompositeFilter<Type> _typeFilters = new CompositeFilter<Type>();
         private BehaviorGraph _graph;
 
-        public BehaviorMatcher()
+        public BehaviorMatcher(Func<Type, MethodInfo, ActionCall> actionCallProvider)
         {
+            _actionCallProvider = actionCallProvider;
             _methodFilters.Excludes += method => method.Method.DeclaringType == typeof (object);
             _methodFilters.Excludes += method => method.Method.DeclaringType == typeof (MarshalByRefObject);
             _methodFilters.Excludes += method => method.Method.DeclaringType == typeof (IDisposable);
@@ -51,7 +52,7 @@ namespace FubuMVC.Core.Registration.Conventions
         private void scanMethods(Type type)
         {
             type.GetMethods(BindingFlags.Instance | BindingFlags.Public)
-                .Select(x => new ActionCall(type, x))
+                .Select(x => _actionCallProvider(type, x))
                 .Where(MethodFilters.Matches)
                 .Each(registerBehavior);
         }


### PR DESCRIPTION
I had originally thought that this would need to be integrated into some of the newer features that create action calls outside of behavior matcher such as the action source matcher, but after looking at it I don't think that will be necessary. This is sufficient for what was needed to enable the asp.net mvc integration.
