### PR TITLE
Mono/Linux adjustments to AssemblyLoader

### DIFF
--- a/src/FubuMVC.Core/Packaging/AssemblyLoader.cs
+++ b/src/FubuMVC.Core/Packaging/AssemblyLoader.cs
@@ -40,8 +40,7 @@ namespace FubuMVC.Core.Packaging
 
         private static bool shouldUpdateFile(string source, string destination)
         {
-            if (!File.Exists(destination)) return true;
-            return File.GetLastWriteTimeUtc(source) != File.GetLastWriteTimeUtc(destination);
+            return !File.Exists(destination) || File.GetLastWriteTimeUtc(source) > File.GetLastWriteTimeUtc(destination);
         }
 
         private bool hasAssemblyByName(string assemblyName)


### PR DESCRIPTION
EditMakes development mode of packages work under mono/linux. Prior to the fix xsp4 would constantly restart (thread abort exception) as the package dlls (even if not changed) would be copied over.
