### PR TITLE
UrlPatternAttribute default value fix

### DIFF
--- a/src/FubuMVC.Core/Registration/Routes/RouteDefinition.cs
+++ b/src/FubuMVC.Core/Registration/Routes/RouteDefinition.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Web.Routing;
 using FubuCore;
 
@@ -44,7 +45,7 @@ namespace FubuMVC.Core.Registration.Routes
 
         public virtual Route ToRoute()
         {
-            var route = new Route(_pattern, null, getConstraints(), null);
+            var route = new Route(PatternWithoutDefaultValues, null, getConstraints(), null);
             if (Input != null)
             {
                 Input.AlterRoute(route);
@@ -62,6 +63,18 @@ namespace FubuMVC.Core.Registration.Routes
         public string Pattern
         {
             get { return _pattern; }
+        }
+
+        public string PatternWithoutDefaultValues
+        {
+            get
+            {
+                const string capture = @":\w+";
+                var pattern = _pattern;
+                return Regex.Matches(pattern, capture, RegexOptions.IgnorePatternWhitespace)
+                    .Cast<Match>()
+                    .Aggregate(pattern, (current, match) => current.Replace(match.Value, string.Empty));
+            }
         }
 
         public void RemoveLastPatternPart()

--- a/src/FubuMVC.Tests/Registration/RouteDefinitionTester.cs
+++ b/src/FubuMVC.Tests/Registration/RouteDefinitionTester.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 using System.Web.Routing;
 using FubuCore;
 using FubuCore.Reflection;
@@ -495,7 +496,15 @@ namespace FubuMVC.Tests.Registration
             route.Constraints["httpMethod"].ShouldEqual(constraintToAdd);
         }
 
+        [Test]
+        public void default_value_syntax_for_urlpattern_produces_correct_route()
+        {
+            var parent = new RouteDefinition("my/sample/{InPath:hello}/{AlsoInPath:world}");
+            parent.Input = new RouteInput<SampleViewModel>(parent);
+
+            var route = parent.ToRoute();
+
+            Assert.IsFalse(Regex.Match(route.Url, @":\w+").Success);
+        }
     }
-
-
 }


### PR DESCRIPTION
As described in this thread
http://groups.google.com/group/fubumvc-devel/browse_thread/thread/bc4f3bd564c25199

Added a way to get at the Pattern with the default values stripped out, changed the ToRoute to use it.
