### PR TITLE
Added fallback option for scripts when using a CDN.

### DIFF
--- a/src/FubuMVC.Core/UI/ContentFileCombinerPackage.cs
+++ b/src/FubuMVC.Core/UI/ContentFileCombinerPackage.cs
@@ -43,9 +43,9 @@ namespace FubuMVC.Core.UI
             _folderService.RegisterDirectory(FileSystem.Combine(FubuMvcPackageFacility.GetApplicationPath(), "content"));
         }
 
-        public IEnumerable<HtmlTag> Write(IEnumerable<string> scripts)
+        public IEnumerable<HtmlTag> Write(IEnumerable<IScript> scripts)
         {
-            var rawFiles = scripts.Select(script => _folderService.FileNameFor(ContentType.scripts, script)).Where(x => x != null).ToArray();
+            var rawFiles = scripts.Select(script => _folderService.FileNameFor(ContentType.scripts, script.Name)).Where(x => x != null).ToArray();
             var combinedName = _fileCombiner.GenerateCombinedFile(rawFiles, "; // src: {0}");
             if (combinedName == null) { return Enumerable.Empty<HtmlTag>(); }
             var scriptUrl = "~/content/{0}".ToFormat(combinedName).ToAbsoluteUrl();

--- a/src/FubuMVC.Core/UI/Scripts/BasicScriptTagWriter.cs
+++ b/src/FubuMVC.Core/UI/Scripts/BasicScriptTagWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using FubuCore;
 using FubuMVC.Core.Content;
 using HtmlTags;
 
@@ -8,19 +9,24 @@ namespace FubuMVC.Core.UI.Scripts
     public class BasicScriptTagWriter : IScriptTagWriter
     {
         private readonly IContentRegistry _registry;
+        private const string FALLBACK = "window.{0} || document.write('<script src=\"{1}\"><\\/script>')";
 
         public BasicScriptTagWriter(IContentRegistry registry)
         {
             _registry = registry;
         }
 
-        public IEnumerable<HtmlTag> Write(IEnumerable<string> scripts)
+        public IEnumerable<HtmlTag> Write(IEnumerable<IScript> scripts)
         {
             return scripts.Select(x =>
             {
                 // TODO -- is it possible that we could have something besides JavaScript?
-                var scriptUrl = _registry.ScriptUrl(x);
-                return new HtmlTag("script").Attr("src", scriptUrl).Attr("type", "text/javascript");
+                var scriptUrl = _registry.ScriptUrl(x.Name);
+                var scriptTag = new HtmlTag("script").Attr("src", scriptUrl).Attr("type", "text/javascript");
+                if(x.HasFallback)
+                    scriptTag.After(new HtmlTag("script").Attr("type", "text/javascript")
+                        .Text(FALLBACK.ToFormat(x.WindowVariableName, x.FallbackName)).Encoded(false));
+                return scriptTag;
             });
         }
 

--- a/src/FubuMVC.Core/UI/Scripts/IScriptObject.cs
+++ b/src/FubuMVC.Core/UI/Scripts/IScriptObject.cs
@@ -5,8 +5,12 @@ namespace FubuMVC.Core.UI.Scripts
     public interface IScriptObject : IEnumerable<IScript>
     {
         string Name { get; }
+        string FallbackName { get; }
+        string WindowVariableName { get; }
+        bool HasFallback { get; }
         bool Matches(string key);
         void AddAlias(string alias);
+        void AddFallback(string fallbackName, string windowVariableName);
 
         IEnumerable<IScript> AllScripts();
         IEnumerable<IScriptObject> Dependencies();

--- a/src/FubuMVC.Core/UI/Scripts/IScriptTagWriter.cs
+++ b/src/FubuMVC.Core/UI/Scripts/IScriptTagWriter.cs
@@ -5,6 +5,6 @@ namespace FubuMVC.Core.UI.Scripts
 {
     public interface IScriptTagWriter
     {
-        IEnumerable<HtmlTag> Write(IEnumerable<string> scripts);
+        IEnumerable<HtmlTag> Write(IEnumerable<IScript> scripts);
     }
 }

--- a/src/FubuMVC.Core/UI/Scripts/ScriptDslReader.cs
+++ b/src/FubuMVC.Core/UI/Scripts/ScriptDslReader.cs
@@ -88,6 +88,11 @@ namespace FubuMVC.Core.UI.Scripts
                     _registration.Alias(tokens.Dequeue(), key);
                     break;
 
+                case "fallback":
+                    if (tokens.Count != 2) throw new InvalidSyntaxException("Two tokens must appear on the right side of the 'fallback' verb");
+                    _registration.Fallback(key, tokens.Dequeue(), tokens.Dequeue());
+                    break;
+
                 case "requires":
                     tokens.Each(name => _registration.Dependency(key, name));
                     break;

--- a/src/FubuMVC.Core/UI/Scripts/ScriptGraph.cs
+++ b/src/FubuMVC.Core/UI/Scripts/ScriptGraph.cs
@@ -10,6 +10,7 @@ namespace FubuMVC.Core.UI.Scripts
     public interface IScriptRegistration
     {
         void Alias(string name, string alias);
+        void Fallback(string name, string windowVariableName, string fallbackName);
         void Dependency(string dependent, string dependency);
         void Extension(string extender, string @base);
         void AddToSet(string setName, string name);
@@ -59,6 +60,11 @@ namespace FubuMVC.Core.UI.Scripts
         public void Alias(string name, string alias)
         {
             _objects[name].AddAlias(alias);
+        }
+
+        public void Fallback(string name, string windowVariable, string fallbackName)
+        {
+            _objects[name].AddFallback(fallbackName, windowVariable);
         }
 
         public void Dependency(string dependent, string dependency)

--- a/src/FubuMVC.Core/UI/Scripts/ScriptObjectBase.cs
+++ b/src/FubuMVC.Core/UI/Scripts/ScriptObjectBase.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using FubuCore;
 
 namespace FubuMVC.Core.UI.Scripts
 {
@@ -17,6 +18,13 @@ namespace FubuMVC.Core.UI.Scripts
         }
 
         public string Name { get; set; }
+        public string FallbackName { get; set; }
+        public string WindowVariableName { get; set; }
+
+        public bool HasFallback
+        {
+            get { return FallbackName.IsNotEmpty(); }
+        }
 
         public void AddAlias(string alias)
         {
@@ -33,6 +41,12 @@ namespace FubuMVC.Core.UI.Scripts
         public void AddDependency(IScriptObject scriptObject)
         {
             _dependencies.Fill(scriptObject);
+        }
+
+        public void AddFallback(string fallbackName, string windowVariableName)
+        {
+            FallbackName = fallbackName;
+            WindowVariableName = windowVariableName;
         }
 
         public IEnumerator<IScript> GetEnumerator()

--- a/src/FubuMVC.Core/UI/Scripts/ScriptRequirements.cs
+++ b/src/FubuMVC.Core/UI/Scripts/ScriptRequirements.cs
@@ -9,7 +9,7 @@ namespace FubuMVC.Core.UI.Scripts
         private readonly IContentFolderService _folders;
         private readonly ScriptGraph _scriptGraph;
         private readonly List<string> _requirements = new List<string>();
-        private readonly List<string> _rendered = new List<string>();
+        private readonly List<IScript> _rendered = new List<IScript>();
 
         public ScriptRequirements(IContentFolderService folders, ScriptGraph scriptGraph)
         {
@@ -40,9 +40,9 @@ namespace FubuMVC.Core.UI.Scripts
         /// </summary>
         /// <remarks>Can be called multiple times within an HTTP request, and will not return any script more than once.</remarks>
         /// <returns></returns>
-        public IEnumerable<string> GetScriptsToRender()
+        public IEnumerable<IScript> GetScriptsToRender()
         {
-            var requiredScripts = _scriptGraph.GetScripts(_requirements).Select(x => x.Name).Except(_rendered).ToList();
+            var requiredScripts = _scriptGraph.GetScripts(_requirements).Except(_rendered).ToList();
             _rendered.AddRange(requiredScripts);
             return requiredScripts;
         }

--- a/src/FubuMVC.Tests/UI/Scripts/BasicScriptTagWriterTester.cs
+++ b/src/FubuMVC.Tests/UI/Scripts/BasicScriptTagWriterTester.cs
@@ -14,16 +14,18 @@ namespace FubuMVC.Tests.UI.Scripts
         [Test]
         public void write_the_tags()
         {
+            var jQuery = new Script("jquery.js");
+            jQuery.AddFallback("jquery-1.5.2.js", "jQuery");
             var scripts = new List<IScript>(){
-                new Script("jquery.js"),
+                jQuery,
                 new Script("script1.js"),
                 new Script("script2.js")
             };
 
             var writer = new BasicScriptTagWriter(new StubContentRegistry());
-            writer.Write(scripts.Select(x => x.Name)).Select(x => x.ToString())
+            writer.Write(scripts).Select(x => x.ToString())
                 .ShouldHaveTheSameElementsAs(
-                "<script src=\"url for jquery.js\" type=\"text/javascript\"></script>", 
+                "<script src=\"url for jquery.js\" type=\"text/javascript\"></script><script type=\"text/javascript\">window.jQuery || document.write('<script src=\"jquery-1.5.2.js\"><\\/script>')</script>",
                 "<script src=\"url for script1.js\" type=\"text/javascript\"></script>", 
                 "<script src=\"url for script2.js\" type=\"text/javascript\"></script>" 
             

--- a/src/FubuMVC.Tests/UI/Scripts/ScriptDslReaderTester.cs
+++ b/src/FubuMVC.Tests/UI/Scripts/ScriptDslReaderTester.cs
@@ -1,3 +1,4 @@
+using System;
 using FubuTestingSupport;
 using FubuMVC.Core.UI.Scripts;
 using NUnit.Framework;
@@ -35,7 +36,6 @@ namespace FubuMVC.Tests.UI.Scripts
             MockFor<IScriptRegistration>().AssertWasCalled(x => x.Dependency("G.js", "F.js"));
         }
     }
-
 
     [TestFixture]
     public class ScriptDslReaderTester : InteractionContext<ScriptDslReader>
@@ -110,6 +110,37 @@ namespace FubuMVC.Tests.UI.Scripts
             MockFor<IScriptRegistration>().AssertWasCalled(x => x.AddToSet("crud", "crudForm.js"));
             MockFor<IScriptRegistration>().AssertWasCalled(x => x.AddToSet("crud", "validation.js"));
             MockFor<IScriptRegistration>().AssertWasCalled(x => x.AddToSet("crud", "stateManager.js"));
+        }
+
+        [Test]
+        public void read_fallback_happy_path()
+        {
+            ClassUnderTest.ReadLine("jquery is https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js");
+            ClassUnderTest.ReadLine("jquery fallback jQuery jquery-1.5.2.min.js");
+
+            MockFor<IScriptRegistration>().AssertWasCalled(x => 
+                x.Fallback("jquery", "jQuery", "jquery-1.5.2.min.js"));
+        }
+
+        [Test]
+        public void negative_case_for_fallback_when_not_enough_tokens_passed_to_verb()
+        {
+            ClassUnderTest.ReadLine("jquery is https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js");
+            Exception<InvalidSyntaxException>.ShouldBeThrownBy(() =>
+            {
+                ClassUnderTest.ReadLine("jquery fallback jQuery");
+            }).Message.ShouldContain("Two tokens must appear on the right side of the 'fallback' verb");
+        }
+
+
+        [Test]
+        public void negative_case_for_fallback_when_too_many_tokens_passed_to_verb()
+        {
+            ClassUnderTest.ReadLine("jquery is https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js");
+            Exception<InvalidSyntaxException>.ShouldBeThrownBy(() =>
+            {
+                ClassUnderTest.ReadLine("jquery fallback jQuery jQuery2 jQuery3");
+            }).Message.ShouldContain("Two tokens must appear on the right side of the 'fallback' verb");
         }
 
         [Test]

--- a/src/FubuMVC.Tests/UI/Scripts/ScriptRequirementsTester.cs
+++ b/src/FubuMVC.Tests/UI/Scripts/ScriptRequirementsTester.cs
@@ -31,7 +31,7 @@ namespace FubuMVC.Tests.UI.Scripts
             ClassUnderTest.Require("jquery.js");
             ClassUnderTest.Require("jquery.js");
 
-            SpecificationExtensions.ShouldEqual(ClassUnderTest.GetScriptsToRender().Single(), "jquery.js");
+            SpecificationExtensions.ShouldEqual(ClassUnderTest.GetScriptsToRender().Select(x => x.Name).Single(), "jquery.js");
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace FubuMVC.Tests.UI.Scripts
             scriptExists("jquery.js");
             ClassUnderTest.UseFileIfExists("jquery.js");
 
-            SpecificationExtensions.ShouldEqual(ClassUnderTest.GetScriptsToRender().Single(), "jquery.js");
+            SpecificationExtensions.ShouldEqual(ClassUnderTest.GetScriptsToRender().Select(x => x.Name).Single(), "jquery.js");
         }
 
         [Test]
@@ -75,11 +75,11 @@ namespace FubuMVC.Tests.UI.Scripts
             ClassUnderTest.Require("a"); // depends on b & c
             ClassUnderTest.Require("f"); // no dependencies
 
-            ClassUnderTest.GetScriptsToRender().ShouldHaveTheSameElementsAs("b", "c", "f", "a");
+            ClassUnderTest.GetScriptsToRender().Select(x => x.Name).ShouldHaveTheSameElementsAs("b", "c", "f", "a");
             // ask for d, get d,e (not b, since it was already written)
 
             ClassUnderTest.Require("d"); // depends on e and b
-            ClassUnderTest.GetScriptsToRender().ShouldHaveTheSameElementsAs("e", "d");
+            ClassUnderTest.GetScriptsToRender().Select(x => x.Name).ShouldHaveTheSameElementsAs("e", "d");
         }
     }
 }


### PR DESCRIPTION
Any objections to me adding to the script DSL for a script fallback? Feel free to give the usual constructive criticism.

originalscript fallback-verb window-variable fallbackscript
http://cdn.googleapis.com/jquery.js fallback jQuery /scripts/jquery-1.5.2.js

becomes

<script>window.jQuery || document.write('<script src="/scripts/jquery-1.5.2.min.js"><\/script>')</script>
