### PR TITLE
Changed the AssertValid Method of ListDependency to make sure each item w

### DIFF
--- a/src/FubuMVC.Core/Registration/ObjectGraph/ListDependency.cs
+++ b/src/FubuMVC.Core/Registration/ObjectGraph/ListDependency.cs
@@ -73,7 +73,7 @@ namespace FubuMVC.Core.Registration.ObjectGraph
 
         public void AssertValid()
         {
-            _items.Each(x => x.ValidatePluggabilityTo(DependencyType));
+            _items.Each(x => x.ValidatePluggabilityTo(ElementType));
         }
 
         public void AddRange(IEnumerable<ObjectDef> items)

--- a/src/FubuMVC.Tests/Registration/ListDependencyTester.cs
+++ b/src/FubuMVC.Tests/Registration/ListDependencyTester.cs
@@ -54,7 +54,42 @@ namespace FubuMVC.Tests.Registration
         }
     }
 
+
+    [TestFixture]
+    public class ListDependency_as_dependency
+    {
+
+        [Test]
+        public void Should_satisfy_dependency()
+        {
+            var def = new ObjectDef(typeof(NeedListOfDoers));
+
+            var doer1 = new ASomethingDoer();
+
+            var doers = new ListDependency(typeof (IEnumerable<ISomethingDoer>));
+            doers.AddValue(doer1);
+            doers.AddType(typeof (BSomethingDoer));
+
+            def.Dependency(doers);
+
+
+            def.Dependencies.ShouldHaveCount(1);
+        }
+        
+    }
+
+    public class NeedListOfDoers
+    {
+        private readonly IEnumerable<ISomethingDoer> _doers;
+
+        public NeedListOfDoers(IEnumerable<ISomethingDoer> doers)
+        {
+            _doers = doers;
+        }
+    }
+
     public interface ISomethingDoer{}
 
     public class ASomethingDoer : ISomethingDoer{}
+    public class BSomethingDoer : ISomethingDoer{}
 }

--- a/src/TestPackage1/.package-manifest
+++ b/src/TestPackage1/.package-manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Role>module</Role>
   <Name>pak1</Name>
   <assembly>TestPackage1</assembly>


### PR DESCRIPTION
Changed the AssertValid Method of ListDependency to make sure each item was valid with the Element Type instead of the list type.

I ran into an issue where ListDependency, as a dependency to another ObjectDef would fail on AssertValid
