### PR TITLE
Introduced ViewDefinitionResolver

### DIFF
--- a/src/FubuMVC.Spark.Tests/FubuMVC.Spark.Tests.csproj
+++ b/src/FubuMVC.Spark.Tests/FubuMVC.Spark.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Rendering\PageActivationTester.cs" />
     <Compile Include="Rendering\SiteResourceAttacherTester.cs" />
     <Compile Include="Rendering\ViewContentDisposerTester.cs" />
+    <Compile Include="Rendering\ViewDefinitionResolverTester.cs" />
     <Compile Include="Rendering\ViewEntryProviderCacheTester.cs" />
     <Compile Include="Rendering\ViewModifierServiceTester.cs" />
     <Compile Include="Rendering\ViewRendererTester.cs" />

--- a/src/FubuMVC.Spark.Tests/Rendering/ViewDefinitionResolverTester.cs
+++ b/src/FubuMVC.Spark.Tests/Rendering/ViewDefinitionResolverTester.cs
@@ -1,0 +1,42 @@
+using FubuMVC.Spark.Rendering;
+using FubuMVC.Spark.SparkModel;
+using FubuTestingSupport;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace FubuMVC.Spark.Tests.Rendering
+{
+    [TestFixture]
+    public class ViewDefinitionResolverTester : InteractionContext<ViewDefinitionResolver>
+    {
+        private IViewDefinitionPolicy[] _policies;
+        private ViewDefinition _defaultDefinition;
+        private ViewDefinition _policyDefinition;
+        private ViewDescriptor _descriptor;
+
+        protected override void beforeEach()
+        {
+            _policies = Services.CreateMockArrayFor<IViewDefinitionPolicy>(5);
+            _descriptor = new ViewDescriptor(MockRepository.GenerateMock<ITemplate>());
+            _policyDefinition = new ViewDefinition(null, null);
+            _defaultDefinition = new ViewDefinition(null, null);
+
+            MockFor<DefaultViewDefinitionPolicy>().Stub(x => x.Create(_descriptor)).Return(_defaultDefinition);
+        }
+
+        [Test]
+        public void if_no_policy_matches_returns_the_view_definition_from_the_default_policy()
+        {
+            ClassUnderTest.Resolve(_descriptor).ShouldEqual(_defaultDefinition);
+        }
+
+        [Test]
+        public void returns_the_view_definition_from_the_matching_policy()
+        {
+            _policies[3].Expect(x => x.Matches(_descriptor)).Return(true);
+            _policies[3].Expect(x => x.Create(_descriptor)).Return(_policyDefinition);
+            ClassUnderTest.Resolve(_descriptor).ShouldEqual(_policyDefinition);
+            _policies[3].VerifyAllExpectations();
+        }
+    }
+}

--- a/src/FubuMVC.Spark.Tests/Rendering/ViewEntrySourceTester.cs
+++ b/src/FubuMVC.Spark.Tests/Rendering/ViewEntrySourceTester.cs
@@ -1,5 +1,4 @@
 ﻿using FubuMVC.Spark.Registration;
-using FubuMVC.Spark.Registration.Nodes;
 using FubuMVC.Spark.Rendering;
 using FubuMVC.Spark.SparkModel;
 using FubuTestingSupport;
@@ -12,8 +11,6 @@ namespace FubuMVC.Spark.Tests.Rendering
     [TestFixture]
     public class ViewEntrySourceTester : InteractionContext<ViewEntrySource>
     {
-        private ViewDescriptor _descriptor;
-        private ViewDefinition _definition;
         private ISparkViewEntry _entry;
         private ISparkViewEntry _partialEntry;
 
@@ -25,58 +22,37 @@ namespace FubuMVC.Spark.Tests.Rendering
             template.Stub(x => x.ViewPath).Return("/Views/Home/index.spark");
             master.Stub(x => x.ViewPath).Return("/Views/Shared/appplication.spark");
 
-            _descriptor = new ViewDescriptor(template) { Master = master };
-            _definition = _descriptor.ToViewDefinition();
+            var descriptor = new ViewDescriptor(template) { Master = master };
+            var definition = descriptor.ToViewDefinition();
+
+            var resolver = MockFor<IViewDefinitionResolver>();
+            resolver.Stub(x => x.Resolve(descriptor)).Return(definition);
 
             _entry = MockRepository.GenerateMock<ISparkViewEntry>();
             _partialEntry = MockRepository.GenerateMock<ISparkViewEntry>();
 
             var provider = MockFor<IViewEntryProviderCache>();
             provider
-                .Stub(x => x.GetViewEntry(_definition.ViewDescriptor))
+                .Stub(x => x.GetViewEntry(definition.ViewDescriptor))
                 .Return(_entry);
             provider
-                .Stub(x => x.GetViewEntry(_definition.PartialDescriptor))
+                .Stub(x => x.GetViewEntry(definition.PartialDescriptor))
                 .Return(_partialEntry);
 
-            Services.Inject(_descriptor);
+            
+            Services.Inject(descriptor);
         }
 
         [Test]
-        public void get_view_entry_uses_the_provider_and_view_descriptor()
+        public void get_view_entry_uses_the_provider_and_view_descriptor_from_the_resolver()
         {
             ClassUnderTest.GetViewEntry().ShouldEqual(_entry);
         }
 
         [Test]
-        public void get_partial_view_entry_uses_the_provider_and_partial_view_descriptor()
+        public void get_partial_view_entry_uses_the_provider_and_partial_view_descriptor_from_the_resolver()
         {
             ClassUnderTest.GetPartialViewEntry().ShouldEqual(_partialEntry);
         }
-
-        [Test]
-        public void when_a_policy_matches_uses_the_generated_definition_to_return_the_view_entry()
-        {
-            var policy = getMockedPolicy();
-            ClassUnderTest.GetViewEntry().ShouldEqual(_entry);
-            policy.VerifyAllExpectations();
-        }
-
-        [Test]
-        public void when_a_policy_matches_uses_the_generated_definition_to_return_the_partial_view_entry()
-        {
-            var policy = getMockedPolicy();
-            ClassUnderTest.GetPartialViewEntry().ShouldEqual(_partialEntry);
-            policy.VerifyAllExpectations();
-        }
-
-        private IViewDefinitionPolicy getMockedPolicy()
-        {
-            var policies = Services.CreateMockArrayFor<IViewDefinitionPolicy>(5);
-            policies[3].Expect(x => x.Matches(_descriptor)).Return(true);
-            policies[3].Expect(x => x.Create(_descriptor)).Return(_definition);
-            return policies[3];
-        }
-
     }
 }

--- a/src/FubuMVC.Spark/FubuMVC.Spark.csproj
+++ b/src/FubuMVC.Spark/FubuMVC.Spark.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Rendering\ViewDefinitionPolicy.cs" />
     <Compile Include="Registration\ViewDescriptorHelper.cs" />
     <Compile Include="Rendering\ViewDefinition.cs" />
+    <Compile Include="Rendering\ViewDefinitionResolver.cs" />
     <Compile Include="Rendering\ViewEntryProviderCache.cs" />
     <Compile Include="SparkModel\FubuBindingProvider.cs" />
     <Compile Include="Registration\Nodes\SparkViewNode.cs" />

--- a/src/FubuMVC.Spark/Rendering/ViewDefinitionPolicy.cs
+++ b/src/FubuMVC.Spark/Rendering/ViewDefinitionPolicy.cs
@@ -24,7 +24,7 @@ namespace FubuMVC.Spark.Rendering
             return true;
         }
 
-        public ViewDefinition Create(ViewDescriptor descriptor)
+        public virtual ViewDefinition Create(ViewDescriptor descriptor)
         {
             return _cache[descriptor];
         }

--- a/src/FubuMVC.Spark/Rendering/ViewDefinitionResolver.cs
+++ b/src/FubuMVC.Spark/Rendering/ViewDefinitionResolver.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using FubuMVC.Spark.SparkModel;
+
+namespace FubuMVC.Spark.Rendering
+{
+    public class ViewDefinitionResolver : IViewDefinitionResolver
+    {
+        private readonly IEnumerable<IViewDefinitionPolicy> _policies;
+        private readonly DefaultViewDefinitionPolicy _defaultPolicy;
+
+        public ViewDefinitionResolver(IEnumerable<IViewDefinitionPolicy> policies, DefaultViewDefinitionPolicy defaultPolicy)
+        {
+            _policies = policies;
+            _defaultPolicy = defaultPolicy;
+        }
+
+        public ViewDefinition Resolve(ViewDescriptor descriptor)
+        {
+            var policy = _policies.FirstOrDefault(x => x.Matches(descriptor)) ?? _defaultPolicy;
+            return policy.Create(descriptor);
+        }
+    }
+    public interface IViewDefinitionResolver
+    {
+        ViewDefinition Resolve(ViewDescriptor descriptor);
+    }
+
+}

--- a/src/FubuMVC.Spark/Rendering/ViewEntrySource.cs
+++ b/src/FubuMVC.Spark/Rendering/ViewEntrySource.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using FubuMVC.Spark.SparkModel;
+﻿using FubuMVC.Spark.SparkModel;
 using Spark;
 
 namespace FubuMVC.Spark.Rendering
@@ -13,19 +11,14 @@ namespace FubuMVC.Spark.Rendering
 
     public class ViewEntrySource : IViewEntrySource
     {
-        private readonly IList<IViewDefinitionPolicy> _policies = new List<IViewDefinitionPolicy>();
         private readonly IViewEntryProviderCache _provider;
         private readonly ViewDescriptor _descriptor;
-
-        public ViewEntrySource(ViewDescriptor descriptor, 
-            IViewEntryProviderCache provider, 
-            IEnumerable<IViewDefinitionPolicy> policies,
-            DefaultViewDefinitionPolicy defaultPolicy)
+        private readonly IViewDefinitionResolver _resolver;
+        public ViewEntrySource(ViewDescriptor descriptor, IViewEntryProviderCache provider, IViewDefinitionResolver resolver)
         {
             _descriptor = descriptor;
             _provider = provider;
-            _policies.AddRange(policies);
-            _policies.Add(defaultPolicy);
+            _resolver = resolver;
         }
 
         public ISparkViewEntry GetViewEntry()
@@ -40,11 +33,10 @@ namespace FubuMVC.Spark.Rendering
 
         private ISparkViewEntry getViewEntry(bool partial)
         {
-            var policy = _policies.First(x => x.Matches(_descriptor));
-            var definition = policy.Create(_descriptor);
+            var definition = _resolver.Resolve(_descriptor);
             var sparkDescriptor = partial ? definition.PartialDescriptor : definition.ViewDescriptor;
             return _provider.GetViewEntry(sparkDescriptor);
         }
-
     }
+
 }

--- a/src/FubuMVC.Spark/SparkEngine.cs
+++ b/src/FubuMVC.Spark/SparkEngine.cs
@@ -150,6 +150,7 @@ namespace FubuMVC.Spark
             services.FillType<IViewModifier, NestedOutputActivation>();
 
             services.SetServiceIfNone(new DefaultViewDefinitionPolicy());
+            services.SetServiceIfNone<IViewDefinitionResolver, ViewDefinitionResolver>();
         }
 
         private IPackageLog getLogger()


### PR DESCRIPTION
Improved ViewEntrySource by making the selection of the matching view definition policy decoupled and isolated into ViewDefinitionResolver.
