### PR TITLE
needed to expose the TagProfile in order to set label and field layouts f

### DIFF
--- a/src/FubuMVC.Core/UI/Tags/TagProfileExpression.cs
+++ b/src/FubuMVC.Core/UI/Tags/TagProfileExpression.cs
@@ -1,3 +1,4 @@
+using System;
 using FubuMVC.Core.UI.Security;
 
 namespace FubuMVC.Core.UI.Tags
@@ -33,5 +34,11 @@ namespace FubuMVC.Core.UI.Tags
         public TagFactoryExpression AfterPartial { get; private set; }
         public PartialTagFactoryExpression BeforeEachOfPartial { get; private set; }
         public PartialTagFactoryExpression AfterEachOfPartial { get; private set; }
+
+        public TagProfileExpression ConfigureProfile(Action<TagProfile> configure)
+        {
+            configure(_profile);
+            return this;
+        }
     }
 }


### PR DESCRIPTION
needed to expose the TagProfile in order to set label and field layouts for a tag profile.
