### PR TITLE
Allowed usage of a generic viewmodel with type argument in spark viewdata

### DIFF
--- a/src/FubuMVC.Spark.Tests/SparkModel/Binding/ViewModelBinderTester.cs
+++ b/src/FubuMVC.Spark.Tests/SparkModel/Binding/ViewModelBinderTester.cs
@@ -55,6 +55,24 @@ namespace FubuMVC.Spark.Tests.SparkModel.Binding
         }
 
         [Test]
+        public void is_able_to_bind_generic_types()
+        {
+            _request.ViewModelType = "FubuMVC.Spark.Tests.SparkModel.Binding.Generic[[FubuMVC.Spark.Tests.SparkModel.Binding.Baz]]";
+            ClassUnderTest.Bind(_request);
+            _descriptor.ViewModel.ShouldEqual(typeof (Generic<Baz>));
+        }
+
+
+        [Test]
+        public void is_able_to_bind_complex_generic_types()
+        {
+            _request.ViewModelType = "FubuMVC.Spark.Tests.SparkModel.Binding.Generic[[FubuMVC.Spark.Tests.SparkModel.Binding.Baz,FubuMVC.Spark.Tests.SparkModel.Binding.Bar]]";
+            ClassUnderTest.Bind(_request);
+            _descriptor.ViewModel.ShouldEqual(typeof(Generic<Baz,Bar>));
+        }
+
+
+        [Test]
         public void it_does_not_try_to_bind_names_that_are_null_or_empty()
         {
             _request.ViewModelType = string.Empty;
@@ -101,6 +119,8 @@ namespace FubuMVC.Spark.Tests.SparkModel.Binding
             pool.AddType(generateType("namespace FubuMVC.Spark.Tests.SparkModel.Binding{public class Bar{}}", "FubuMVC.Spark.Tests.SparkModel.Binding.Bar"));
             pool.AddType<Bar>();
             pool.AddType<Baz>();
+            pool.AddType<Generic<Baz>>();
+            pool.AddType<Generic<Baz, Bar>>();
 
             return pool;
         }
@@ -123,4 +143,13 @@ namespace FubuMVC.Spark.Tests.SparkModel.Binding
 
     public class Bar { }
     public class Baz { }
+    public class Generic<T>
+    {
+    }
+
+    public class Generic<T1, T2>
+    {
+        
+    }
+
 }

--- a/src/FubuMVC.Spark/FubuMVC.Spark.csproj
+++ b/src/FubuMVC.Spark/FubuMVC.Spark.csproj
@@ -103,6 +103,7 @@
     <Compile Include="SparkActivator.cs" />
     <Compile Include="SparkEngine.cs" />
     <Compile Include="SparkModel\SparkLogger.cs" />
+    <Compile Include="SparkModel\Utils\PrettyTypeNamesExtensions.cs" />
     <Compile Include="SparkViewFacility.cs" />
     <Compile Include="SparkViewToken.cs" />
     <Compile Include="Rendering\FubuSparkView.cs" />

--- a/src/FubuMVC.Spark/SparkModel/TemplateBinders.cs
+++ b/src/FubuMVC.Spark/SparkModel/TemplateBinders.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FubuCore;
 using FubuMVC.Core.Registration;
+using FubuMVC.Spark.SparkModel.Utils;
 
 namespace FubuMVC.Spark.SparkModel
 {
@@ -114,7 +115,7 @@ namespace FubuMVC.Spark.SparkModel
             var template = request.Target;
             var descriptor = template.Descriptor.As<ViewDescriptor>();
 
-            var types = request.Types.TypesWithFullName(request.ViewModelType);
+            var types = request.Types.TypesMatching(type => type.PrettyFullName() == request.ViewModelType);
             var typeCount = types.Count();
 
             if (typeCount == 1)

--- a/src/FubuMVC.Spark/SparkModel/Utils/PrettyTypeNamesExtensions.cs
+++ b/src/FubuMVC.Spark/SparkModel/Utils/PrettyTypeNamesExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FubuMVC.Spark.SparkModel.Utils
+{
+    public static class PrettyTypeNamesExtensions
+    {
+        public static string PrettyFullName(this Type type)
+        {
+            if (type.IsGenericType)
+            {
+                var innerTypes = type
+                    .GetGenericArguments()
+                    .Select(t => t.PrettyFullName())
+                    .ToArray()
+                    .Join(",");
+
+                var name = type.Name.Split('`').First();
+                return string.Format("{0}.{1}[[{2}]]", type.Namespace, name, innerTypes);
+            }
+            return type.FullName;
+        }
+    }
+}


### PR DESCRIPTION
Allowed usage of a generic viewmodel with type argument in spark viewdata.
Syntax is: FullGenericTypeName[[FullTypeName]]
