### PR TITLE
Added generic UrlFor<> extension method to IUrlRegistry.

### DIFF
--- a/src/FubuMVC.Core/Urls/IUrlRegistry.cs
+++ b/src/FubuMVC.Core/Urls/IUrlRegistry.cs
@@ -15,6 +15,7 @@ namespace FubuMVC.Core.Urls
     {
         string UrlFor(object model);
         string UrlFor(object model, string category);
+        string UrlFor<TInput>() where TInput : class, new();
         string UrlFor<TController>(Expression<Action<TController>> expression);
 
 
@@ -37,15 +38,19 @@ namespace FubuMVC.Core.Urls
 
     public static class UrlRegistryExtensions
     {
-        public static string UrlFor<TInput>(this IUrlRegistry registry, RouteParameters parameters)
+        public static string UrlFor<TInput>(this IUrlRegistry registry) where TInput : class, new()
         {
-            return registry.UrlFor(typeof (TInput), parameters);
+            return registry.UrlFor(new TInput());
         }
 
+        public static string UrlFor<TInput>(this IUrlRegistry registry, RouteParameters parameters)
+        {
+            return registry.UrlFor(typeof(TInput), parameters);
+        }
 
         public static string UrlFor<TInput>(this IUrlRegistry urls, string category, RouteParameters parameters)
         {
-            return urls.UrlFor(typeof (TInput), category, parameters);
+            return urls.UrlFor(typeof(TInput), category, parameters);
         }
 
         public static string UrlFor<T>(this IUrlRegistry registry, Action<RouteParameters<T>> configure)
@@ -61,7 +66,7 @@ namespace FubuMVC.Core.Urls
             var parameters = new RouteParameters<T>();
             configure(parameters);
 
-            return registry.UrlFor(typeof (T), category, parameters);
+            return registry.UrlFor(typeof(T), category, parameters);
         }
     }
 
@@ -73,6 +78,11 @@ namespace FubuMVC.Core.Urls
             return "url for " + model;
         }
 
+        public string UrlFor<TInput>() where TInput : class, new()
+        {
+            return "url for " + new TInput();
+        }
+
         public string UrlFor(object model, string category)
         {
             return UrlFor(model) + ", category=" + category;
@@ -80,7 +90,7 @@ namespace FubuMVC.Core.Urls
 
         public string UrlFor<TController>(Expression<Action<TController>> expression)
         {
-            return "url for " + typeof (TController).FullName + "." + ReflectionHelper.GetMethod(expression).Name + "()";
+            return "url for " + typeof(TController).FullName + "." + ReflectionHelper.GetMethod(expression).Name + "()";
         }
 
         public string UrlFor(Type modelType, RouteParameters parameters)
@@ -95,7 +105,7 @@ namespace FubuMVC.Core.Urls
 
         public string UrlForNew<T>()
         {
-            return "url for new " + typeof (T).FullName;
+            return "url for new " + typeof(T).FullName;
         }
 
         public string UrlForNew(Type entityType)

--- a/src/FubuMVC.Core/Urls/UrlRegistry.cs
+++ b/src/FubuMVC.Core/Urls/UrlRegistry.cs
@@ -23,6 +23,11 @@ namespace FubuMVC.Core.Urls
             return For(model);
         }
 
+        public string UrlFor<TInput>() where TInput : class, new()
+        {
+            return For(new TInput());
+        }
+
         public string UrlFor(object model, string category)
         {
             return For(model, category);

--- a/src/FubuMVC.HelloWorld/Controllers/Home/Home.aspx
+++ b/src/FubuMVC.HelloWorld/Controllers/Home/Home.aspx
@@ -15,7 +15,7 @@
      <br />
     Number of files attached: <%: Model.NumberOfFiles %>
     <br />
-    <form method="post" enctype="multipart/form-data" action="<%= Urls.UrlFor(new HomeFilesModel()) %>">
+    <form method="post" enctype="multipart/form-data" action="<%= Urls.UrlFor<HomeFilesModel>() %>">
     <br />
     File 1:  <input type="file" name="homefiles" />
     <br />

--- a/src/FubuMVC.Tests/Resources/LinksSourceTester.cs
+++ b/src/FubuMVC.Tests/Resources/LinksSourceTester.cs
@@ -96,6 +96,11 @@ namespace FubuMVC.Tests.Resources
             return "http://somewhere.com/" + model.ToString();
         }
 
+        public string UrlFor<TInput>() where TInput : class, new()
+        {
+            return "http://somewhere.com/" + (new TInput()).ToString();
+        }
+
         public string UrlFor(object model, string category)
         {
             throw new NotImplementedException();

--- a/src/FubuMVC.Tests/Urls/UrlRegistryIntegrationTester.cs
+++ b/src/FubuMVC.Tests/Urls/UrlRegistryIntegrationTester.cs
@@ -62,7 +62,11 @@ namespace FubuMVC.Tests.Urls
             urls.UrlFor(new Model1()).ShouldEqual("Fubu/one/m1");
         }
 
-
+        [Test]
+        public void retrieve_a_url_for_a_inferred_model_simple_case()
+        {
+            urls.UrlFor<Model1>().ShouldEqual("Fubu/one/m1");
+        }
 
         [Test]
         public void retrieve_a_url_for_a_model_that_does_not_exist()


### PR DESCRIPTION
(nb: simple amendment to make sure I've got my Git workflow in order)

We use the UrlFor extension method quite a bit to generate Url's (for form action attributes/etc) but naturally adopt the inferred/generic approach opposed to explicit new'ing; for example:

<%= Urls.UrlFor(new HomeFilesModel()) %>

.. becomes ..

<%= Urls.UrlFor<HomeFilesModel>() %>

Have tried to implement the same pattern of tests as per other extension methods, hope you agree it's worthy and sufficient. As part of the submissions I've changed the HelloWorld Home.aspx to reflect usage of this new method.
