### PR TITLE
Fix for Issue #193 - don't trim a url's trailing slash if it is only a slash

### DIFF
--- a/src/FubuMVC.Core/Http/AspNet/AspNetCurrentHttpRequest.cs
+++ b/src/FubuMVC.Core/Http/AspNet/AspNetCurrentHttpRequest.cs
@@ -36,9 +36,9 @@ namespace FubuMVC.Core.Http.AspNet
                 url = "~/" + url.TrimStart('/');
             }
 
+            var absoluteUrl = VirtualPathUtility.ToAbsolute(url);
             
-
-            return VirtualPathUtility.ToAbsolute(url).TrimEnd('/');
+            return (absoluteUrl != "/") ? absoluteUrl.TrimEnd('/') : absoluteUrl;
         }
 
         public string HttpMethod()

--- a/src/FubuMVC.HelloSpark/Controllers/Air/AirController.cs
+++ b/src/FubuMVC.HelloSpark/Controllers/Air/AirController.cs
@@ -1,10 +1,12 @@
-﻿namespace FubuMVC.HelloSpark.Controllers.Air
+﻿using FubuCore;
+
+namespace FubuMVC.HelloSpark.Controllers.Air
 {
     public class AirController
     {
-        public AirViewModel TakeABreath()
+        public AirViewModel TakeABreath(AirRequest request)
         {
-            return new AirViewModel { Text = "Take a breath?" };
+            return new AirViewModel { Text = "Take a {0} breath?".ToFormat(request.Type) };
         }
 
         public BreatheViewModel Breathe(AirInputModel model)
@@ -15,6 +17,16 @@
 
             return result;
         }
+    }
+
+    public class AirRequest
+    {
+        public AirRequest()
+        {
+            Type = "deep";
+        }
+
+        public string Type { get; set; }
     }
 
     public class AirInputModel

--- a/src/FubuMVC.HelloSpark/HelloSparkRegistry.cs
+++ b/src/FubuMVC.HelloSpark/HelloSparkRegistry.cs
@@ -22,7 +22,7 @@ namespace FubuMVC.HelloSpark
             ApplyHandlerConventions();
 
             Routes
-                .HomeIs<AirController>(c => c.TakeABreath())
+                .HomeIs<AirRequest>()
                 .IgnoreControllerNamespaceEntirely()
                 .IgnoreMethodSuffix("Command")
                 .IgnoreMethodSuffix("Query")

--- a/src/FubuMVC.HelloSpark/Shared/Application.spark
+++ b/src/FubuMVC.HelloSpark/Shared/Application.spark
@@ -17,5 +17,8 @@
         <div>no footer by default</div>
       </use>
     </div>
+    
+    <p>You can always !{this.LinkTo<FubuMVC.HelloSpark.Controllers.Air.AirRequest>().Text("go home")}.
+    </p>
   </body>
 </html>

--- a/src/FubuMVC.Tests/Urls/UrlRegistryIntegrationTester.cs
+++ b/src/FubuMVC.Tests/Urls/UrlRegistryIntegrationTester.cs
@@ -43,7 +43,7 @@ namespace FubuMVC.Tests.Urls
 
 
             registry.ResolveTypes(x => x.AddStrategy<UrlModelForwarder>());
-
+            registry.Routes.HomeIs<DefaultModel>();
 
             graph = registry.BuildGraph();
 
@@ -62,6 +62,12 @@ namespace FubuMVC.Tests.Urls
         public void retrieve_a_url_for_a_model_simple_case()
         {
             urls.UrlFor(new Model1()).ShouldEqual("http://server/fubu/one/m1");
+        }
+        
+        [Test]
+        public void retrieve_a_url_for_the_default_model()
+        {
+            urls.UrlFor(new DefaultModel()).ShouldEqual("http://server/fubu");
         }
 
         [Test]
@@ -279,6 +285,11 @@ namespace FubuMVC.Tests.Urls
 
         [UrlRegistryCategory("different")]
         public void M4(UrlModel model) { }
+
+        public string Default(DefaultModel model)
+        {
+            return "welcome to the default view";
+        }
     }
 
     public class TwoController
@@ -313,6 +324,7 @@ namespace FubuMVC.Tests.Urls
     public class Model5{}
     public class Model6{}
     public class Model7{}
+    public class DefaultModel { }
     public class ModelWithNoChain{}
     public class ModelWithoutNewUrl{}
 


### PR DESCRIPTION
Default routes were rendering as empty strings on Asp.Net hosts due to aggressive slash trimming.
- The pure fix is in AspNetCurrentHttpRequest.cs
- This was monkey tested via HelloSpark hence those files getting touched by this pull request.
- A UrlRegistry integration test was added for default routes to try to reproduce the issue. I left it in there as it doesn't hurt.

This pull request will close issue #193.
