### PR TITLE
Removed references to Microsoft.Web.Infrastructure

### DIFF
--- a/fubuTemplates/default/src/FUBUPROJECTNAME/FUBUPROJECTNAME.csproj
+++ b/fubuTemplates/default/src/FUBUPROJECTNAME/FUBUPROJECTNAME.csproj
@@ -58,8 +58,6 @@
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\packages\CommonServiceLocator\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure">
-      <HintPath>..\..\..\..\src\packages\FubuMVC.0.9.1.656\lib\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Spark">
       <HintPath>..\packages\Spark\lib\NET40\Spark.dll</HintPath>

--- a/packaging/nuget/fubumvc.nuspec
+++ b/packaging/nuget/fubumvc.nuspec
@@ -23,7 +23,6 @@
     <file src="ConfigureFubuMVC.cs.pp" target="content" />
     <file src="web.config.transform" target="content" />
     <file src="..\..\src\FubuMVC.GettingStarted\bin\release\FubuMVC.GettingStarted.dll" target="content\fubu-content" />
-	<file src="..\..\build\fubumvc-diagnostics.zip" target="content\fubu-content" />	
-    <file src="..\..\lib\Microsoft.Web.Infrastructure\Microsoft.Web.Infrastructure.dll" target="lib"/>
+    <file src="..\..\build\fubumvc-diagnostics.zip" target="content\fubu-content" />	
   </files>
 </package>

--- a/src/QuickStart/QuickStart.csproj
+++ b/src/QuickStart/QuickStart.csproj
@@ -48,9 +48,6 @@
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure">
-      <HintPath>..\..\lib\Microsoft.Web.Infrastructure\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
     <Reference Include="Spark">
       <HintPath>..\packages\Spark.1.6\lib\NET40\Spark.dll</HintPath>
     </Reference>


### PR DESCRIPTION
As discussed on Twitter having to deploy Microsoft.Web.Infrastructure is a pain as our boxes are spun up and auto-deployed and therefore bare of any Microsoft pollution; it would be nice to exclude it completely!
