### PR TITLE
Set json content type on the adv diag requests and routes ajax calls

### DIFF
--- a/src/FubuMVC.Diagnostics/Content/Scripts/requests.js
+++ b/src/FubuMVC.Diagnostics/Content/Scripts/requests.js
@@ -195,6 +195,7 @@
             type: "POST",
             url: grid().metadata().url,
             data: JSON.stringify(params),
+			contentType: "application/json",
             dataType: "json",
             success: function(data) {
                 $('#NoData').hide();

--- a/src/FubuMVC.Diagnostics/Content/Scripts/routes.js
+++ b/src/FubuMVC.Diagnostics/Content/Scripts/routes.js
@@ -195,6 +195,7 @@
             type: "POST",
             url: grid().metadata().url,
             data: JSON.stringify(params),
+			contentType: "application/json",
             dataType: "json",
             success: function(data) {
                 grid()[0].addJSONData(data);


### PR DESCRIPTION
Currently the content type is not explicitly set so jQuery defaults to form url encoded. This fixes the paging and filtering on the requests and routes adv diag pages.
