### PR TITLE
Internet Explorer does not support type="application/javascript"

### DIFF
--- a/src/FubuMVC.Core/Assets/Tags/AssetTagBuilder.cs
+++ b/src/FubuMVC.Core/Assets/Tags/AssetTagBuilder.cs
@@ -26,7 +26,8 @@ namespace FubuMVC.Core.Assets.Tags
             _builders[MimeType.Javascript] = (subject, url) =>
             {
                 return new HtmlTag("script")
-                    .Attr("type", MimeType.Javascript.Value)
+                    // http://stackoverflow.com/a/1288319/75194 
+                    .Attr("type", "text/javascript")
                     .Attr("src", url);
             };
 

--- a/src/FubuMVC.Tests/Assets/Tags/AssetTagBuilderTester.cs
+++ b/src/FubuMVC.Tests/Assets/Tags/AssetTagBuilderTester.cs
@@ -35,7 +35,7 @@ namespace FubuMVC.Tests.Assets.Tags
 
             var tag = ClassUnderTest.Build(plan).Single();
 
-            tag.ToString().ShouldEqual("<script type=\"application/javascript\" src=\"http://myapp/_content/scripts/script.js\"></script>");
+            tag.ToString().ShouldEqual("<script type=\"text/javascript\" src=\"http://myapp/_content/scripts/script.js\"></script>");
         
         }
 


### PR DESCRIPTION
Internet Explorer does not support type="application/javascript"
for script tags

Clearly IE is so pants on head retarded that we don't even bother
to open it and test things anymore.

I spent a couple of hours punching myself in the dick trying to use
IE's developer tools trying to figure out why $ was undefined

After putting alert("say something motha !@#$a!"); in jquery.js
and not getting anything back and raging (╯°□°）╯︵ ┻━┻
flipping tables I saw the application/javascript and thought
maybe its that and it was.

Silly IE when will you finally die
