### PR TITLE
Improved async error handling

### DIFF
--- a/src/FubuMVC.Core/FubuMVC.Core.csproj
+++ b/src/FubuMVC.Core/FubuMVC.Core.csproj
@@ -228,7 +228,10 @@
     <Compile Include="Resources\Media\ValuesExtensions.cs" />
     <Compile Include="Runtime\AspNetPassthroughConverter.cs" />
     <Compile Include="Runtime\AsyncBehaviorInvoker.cs" />
+    <Compile Include="Runtime\AsyncExtensions.cs" />
+    <Compile Include="Runtime\ExceptionHandlingObserver.cs" />
     <Compile Include="Runtime\FubuAsyncRouteHandler.cs" />
+    <Compile Include="Runtime\IExceptionHandler.cs" />
     <Compile Include="Runtime\IFubuRouteHandler.cs" />
     <Compile Include="UI\HtmlConventionsActivator.cs" />
     <Compile Include="Http\AspNet\AspNetAggregateDictionary.cs" />

--- a/src/FubuMVC.Core/Registration/Conventions/AsyncContinueWithHandlerConvention.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/AsyncContinueWithHandlerConvention.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FubuMVC.Core.Behaviors;
 using FubuMVC.Core.Registration.Nodes;
 
 namespace FubuMVC.Core.Registration.Conventions
@@ -11,7 +12,8 @@ namespace FubuMVC.Core.Registration.Conventions
         {
             graph.Actions().Where(x => x.IsAsync).Each(call =>
             {
-                call.AddAfter(call.Method.ReturnType == typeof (Task)
+                call.WrapWith<AsyncInterceptExceptionBehavior>();
+                call.AddAfter(call.Method.ReturnType == typeof(Task)
                                   ? new AsyncContinueWithNode()
                                   : new AsyncContinueWithNode(call.OutputType()));
                 graph.Observer.RecordCallStatus(call, "Adding AsyncContinueWithNode directly after action call");

--- a/src/FubuMVC.Core/Runtime/AsyncExtensions.cs
+++ b/src/FubuMVC.Core/Runtime/AsyncExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+namespace FubuMVC.Core.Runtime
+{
+    public static class AsyncExtensions
+    {
+         public static void FinishProcessingTask(this Task task, IExceptionHandlingObserver observer)
+         {
+             if (task.IsFaulted)
+             {
+                 var aggregateException = task.Exception.Flatten();
+                 var allHandled = aggregateException.InnerExceptions.All(observer.WasObserved);
+                 if (!allHandled)
+                 {
+                     task.Wait();
+                 }
+             }
+         }
+    }
+}

--- a/src/FubuMVC.Core/Runtime/ExceptionHandlingObserver.cs
+++ b/src/FubuMVC.Core/Runtime/ExceptionHandlingObserver.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FubuMVC.Core.Runtime
+{
+    public class ExceptionHandlingObserver : IExceptionHandlingObserver
+    {
+        private readonly IList<Exception> _handled = new List<Exception>();
+
+        public void RecordHandled(Exception exception)
+        {
+            _handled.Add(exception);
+        }
+
+        public bool WasObserved(Exception exception)
+        {
+            return _handled.Contains(exception);
+        }
+    }
+
+    public interface IExceptionHandlingObserver
+    {
+        void RecordHandled(Exception exception);
+        bool WasObserved(Exception exception);
+    }
+}

--- a/src/FubuMVC.Core/Runtime/IExceptionHandler.cs
+++ b/src/FubuMVC.Core/Runtime/IExceptionHandler.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace FubuMVC.Core.Runtime
+{
+    public interface IExceptionHandler
+    {
+        bool ShouldHandle(Exception exception);
+        void Handle(Exception exception);
+    }
+}

--- a/src/FubuMVC.HelloSpark/AsyncErrorHandling.cs
+++ b/src/FubuMVC.HelloSpark/AsyncErrorHandling.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using FubuMVC.Core.Runtime;
+
+namespace FubuMVC.HelloSpark
+{
+    public class AsyncExceptionHandler : IExceptionHandler
+    {
+        private readonly IOutputWriter _output;
+
+        public AsyncExceptionHandler(IOutputWriter output)
+        {
+            _output = output;
+        }
+
+        public bool ShouldHandle(Exception exception)
+        {
+            return !(exception is DontHandleException);
+        }
+
+        public void Handle(Exception exception)
+        {
+            _output.WriteHtml("Handled Exception");
+        }
+    }
+
+    public class DontHandleException : Exception
+    {
+        
+    }
+}

--- a/src/FubuMVC.HelloSpark/Controllers/Sleep/RemAsync.spark
+++ b/src/FubuMVC.HelloSpark/Controllers/Sleep/RemAsync.spark
@@ -8,3 +8,5 @@
 ${this.Partial<PartialSleepInputModel>()}
 
 !{this.LinkTo<SleepController>(c => c.BadDreamAsync()).Text("I prefer not to sleep, take me somewhere else!")}
+!{this.LinkTo<HandleExceptionAsyncInput>().Text("Handle an async exception...")}
+!{this.LinkTo<DontHandleExceptionAsyncInput>().Text("Don't handle an async exception...")}

--- a/src/FubuMVC.HelloSpark/Controllers/Sleep/SleepController.cs
+++ b/src/FubuMVC.HelloSpark/Controllers/Sleep/SleepController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FubuCore;
 using FubuMVC.Core.Continuations;
@@ -46,7 +47,25 @@ namespace FubuMVC.HelloSpark.Controllers.Sleep
                 };
             }, TaskCreationOptions.AttachedToParent);
         }
+
+        public Task HandleExceptionAsync(HandleExceptionAsyncInput input)
+        {
+            throw new Exception();
+        }
+
+        public Task DontHandleExceptionAsync(DontHandleExceptionAsyncInput input)
+        {
+            throw new DontHandleException();
+        }
     }
+
+    public class HandleExceptionAsyncInput
+    {
+    }
+
+    public class DontHandleExceptionAsyncInput
+    {
+    }  
 
     public class RemViewModel
     {

--- a/src/FubuMVC.HelloSpark/FubuMVC.HelloSpark.csproj
+++ b/src/FubuMVC.HelloSpark/FubuMVC.HelloSpark.csproj
@@ -110,6 +110,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AsyncErrorHandling.cs" />
     <Compile Include="Controllers\Family\FamilyController.cs" />
     <Compile Include="Controllers\Sleep\SleepController.cs" />
     <Compile Include="Controllers\ThreePassRendering\ThreePassController.cs" />

--- a/src/FubuMVC.HelloSpark/HelloSparkRegistry.cs
+++ b/src/FubuMVC.HelloSpark/HelloSparkRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using FubuMVC.Core;
+using FubuMVC.Core.Runtime;
 using FubuMVC.Core.Security.AntiForgery;
 using FubuMVC.Core.UI.Extensibility;
 using FubuMVC.Core.Urls;
@@ -39,7 +40,11 @@ namespace FubuMVC.HelloSpark
 
             HtmlConvention<SampleHtmlConventions>();
 						
-            Services(s => s.ReplaceService<IUrlTemplatePattern, JQueryUrlTemplate>());
+            Services(s =>
+            {
+                s.FillType<IExceptionHandler, AsyncExceptionHandler>();
+                s.ReplaceService<IUrlTemplatePattern, JQueryUrlTemplate>();
+            });
 
             this.Extensions()
                 .For<AirViewModel>("extension-placeholder", x => "<p>Rendered from content extension.</p>");

--- a/src/FubuMVC.OwinHost/FubuOwinHost.cs
+++ b/src/FubuMVC.OwinHost/FubuOwinHost.cs
@@ -69,12 +69,16 @@ namespace FubuMVC.OwinHost
             var arguments = new OwinServiceArguments(routeData, request, response);
             var invoker = routeData.RouteHandler.As<FubuRouteHandler>().Invoker;
 
+            var exceptionHandlingObserver = new ExceptionHandlingObserver();
+            arguments.Set(typeof(IExceptionHandlingObserver), exceptionHandlingObserver);
+
             var task = Task.Factory.StartNew(() => invoker.Invoke(arguments, routeData.Values));
+
             task.ContinueWith(x =>
             {
                 try
                 {
-                    x.Wait();
+                    x.FinishProcessingTask(exceptionHandlingObserver);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
The error handling for async requests work now with samples
Introduced IExceptionHandler to make handling errors
for async requests less difficult

The introduction of the exception observer wasn't my favorite, but I don't think there's any way to avoid it at this point.

Let me know if there are any questions.
