### PR TITLE
Conneg output behavior with wildcard accept headers now render as HTML

### DIFF
--- a/src/FubuMVC.Core/Resources/Conneg/ConnegOutputBehavior.cs
+++ b/src/FubuMVC.Core/Resources/Conneg/ConnegOutputBehavior.cs
@@ -28,12 +28,14 @@ namespace FubuMVC.Core.Resources.Conneg
         protected override DoNext performInvoke()
         {
             var mimeTypes = _request.Get<CurrentMimeType>();
-            if (mimeTypes.AcceptTypes.Contains(MediaTypeNames.Text.Html))
+
+            var writer = SelectWriter(mimeTypes);
+
+            if (writer == null && isHtmlMimeType(mimeTypes))
             {
                 return DoNext.Continue;
             }
 
-            var writer = SelectWriter(mimeTypes);
             if (writer == null)
             {
                 _writer.WriteResponseCode(HttpStatusCode.NotAcceptable);
@@ -46,16 +48,16 @@ namespace FubuMVC.Core.Resources.Conneg
             return DoNext.Stop;
         }
 
+        private static bool isHtmlMimeType(CurrentMimeType mimeTypes)
+        {
+            return mimeTypes.AcceptTypes.Contains(MediaTypeNames.Text.Html)
+                   || mimeTypes.AcceptTypes.Contains("*/*");
+        }
+
         public virtual IMediaWriter<T> SelectWriter(CurrentMimeType mimeTypes)
         {
             foreach (var acceptType in mimeTypes.AcceptTypes)
             {
-                if (acceptType == "*/*")
-                {
-                    return _writers.FirstOrDefault(x => x.Mimetypes.Contains(MediaTypeNames.Text.Html))
-                           ?? _writers.FirstOrDefault();
-                }
-
                 var writer = _writers.FirstOrDefault(x => x.Mimetypes.Contains(acceptType));
                 if (writer != null) return writer;
             }


### PR DESCRIPTION
Currently conneg enabled requests get JSON back when the accept header is a wildcard:

`Accept: */*`

Sadly old IE, embedded in our case, _forgets_ to send the proper accept header. So that sucks.

Looking at the code I think the intent is to have `Accept:*/*` be handled like HTML but it is not currently working that way. 

This pull request changes the Conneg output behavior to try to find a IMediaWriter. If no writer is found and the Accept type is `text/html` or `*/*` a `Do.Continue` will happen. 

Note: This is not exactly what was happening before. Currently when the accepted mime type contains `text/html` the writer selection process is skipped. I thought it best to not hard code wildcard and html output support in the case where a writer is added which specifically handles these mime types.
