### PR TITLE
Minor fix for CombineAllUniqueSetsCombinationDeterminationService

### DIFF
--- a/src/FubuMVC.Core/Assets/Combination/CombineAllUniqueSetsCombinationDeterminationService.cs
+++ b/src/FubuMVC.Core/Assets/Combination/CombineAllUniqueSetsCombinationDeterminationService.cs
@@ -1,22 +1,25 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FubuMVC.Core.Assets.Combination
 {
     /// <summary>
-    /// Simplistic combination just creates a combination for ever unique set of scripts or styles
+    /// Simplistic combination that creates a combination for every unique set of scripts or styles.
+    /// It does not try to cross mimetype boundaries.
     /// </summary>
     public class CombineAllUniqueSetsCombinationDeterminationService : CombinationDeterminationService
     {
         // TODO -- this is going to have to be hit with integrated tests
 
         public CombineAllUniqueSetsCombinationDeterminationService(IAssetCombinationCache combinations)
-            : base(combinations, new List<ICombinationPolicy>() { new CombineAllScriptFiles(), new CombineAllStylesheets() })
+            : base(combinations, new List<ICombinationPolicy> { new CombineAllScriptFiles(), new CombineAllStylesheets() })
         {
         }
 
         public override void TryToReplaceWithCombinations(AssetTagPlan plan)
         {
-            policies.Each(p => ExecutePolicy(plan, p));
+            var mimeTypePolicies = policies.Where(x => x.MimeType == plan.MimeType);
+            mimeTypePolicies.Each(p => ExecutePolicy(plan, p));
             base.TryToReplaceWithCombinations(plan);
         }
     }

--- a/src/FubuMVC.Tests/Assets/Combination/CombineAllUniqueSetsCombinationDeterminationServiceTester.cs
+++ b/src/FubuMVC.Tests/Assets/Combination/CombineAllUniqueSetsCombinationDeterminationServiceTester.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using FubuMVC.Core.Assets.Combination;
+using FubuMVC.Core.Assets.Files;
+using FubuMVC.Core.Runtime;
+using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuMVC.Tests.Assets.Combination
+{
+    [TestFixture]
+    public class CombineAllUniqueSetsCombinationDeterminationServiceTester : InteractionContext<CombineAllUniqueSetsCombinationDeterminationService>
+    {
+        protected override void beforeEach()
+        {
+            Services.Inject<IAssetCombinationCache>(new AssetCombinationCache());
+        }
+
+        [Test]
+        public void executes_correct_policy_1()
+        {
+            run_with_plan(new AssetTagPlan(MimeType.Javascript, new[]
+            {
+                new AssetFile("A.css"), new AssetFile("B.css")
+            }));
+        }
+
+        [Test]
+        public void executes_correct_policy_2()
+        {
+            run_with_plan(new AssetTagPlan(MimeType.Javascript, new[]
+            {
+                new AssetFile("C.js"), new AssetFile("D.js")
+            }));
+        }
+
+
+        private void run_with_plan(AssetTagPlan plan)
+        {
+            ClassUnderTest.TryToReplaceWithCombinations(plan);
+            
+            plan.Subjects.ShouldHaveCount(1)
+                .First().MimeType.ShouldEqual(plan.MimeType);
+        }
+    }
+}

--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Assets\Combination\CombinationDeterminationServiceTester.cs" />
     <Compile Include="Assets\Combination\CombineAllScriptFilesTester.cs" />
     <Compile Include="Assets\Combination\CombineAllStyleSheetsTester.cs" />
+    <Compile Include="Assets\Combination\CombineAllUniqueSetsCombinationDeterminationServiceTester.cs" />
     <Compile Include="Assets\Combination\ScriptFileCombinationTester.cs" />
     <Compile Include="Assets\Combination\StyleFileCombinationTester.cs" />
     <Compile Include="Assets\Content\CombinationTester.cs" />


### PR DESCRIPTION
It ensures mimetype on plan matches with the one on policy.

@jeremydmiller 

We could perhaps rather do the filtering in ExecutePolicy or similar in order to avoid code duplication.
