### PR TITLE
Removed problematic uses of HttpContext.Current

### DIFF
--- a/src/FubuMVC.Core/Diagnostics/DebugReport.cs
+++ b/src/FubuMVC.Core/Diagnostics/DebugReport.cs
@@ -16,6 +16,7 @@ namespace FubuMVC.Core.Diagnostics
 
     public class DebugReport : TimedReport, IEnumerable<BehaviorReport>, IDebugReport
     {
+        private readonly HttpContextBase _httpContext;
         private readonly IList<BehaviorReport> _behaviors = new List<BehaviorReport>();
         private readonly Stack<BehaviorReport> _behaviorStack = new Stack<BehaviorReport>();
         private readonly IList<BehaviorStep> _steps = new List<BehaviorStep>();
@@ -33,18 +34,22 @@ namespace FubuMVC.Core.Diagnostics
             Time = DateTime.Now;
         }
 
+        public DebugReport(HttpContextBase httpContext) : this()
+        {
+            _httpContext = httpContext;
+        }
+
         // TODO -- this is a no go for OWIN support
         public void RecordFormData()
         {
             try
             {
-                var context = HttpContext.Current;
-                if (context != null && context.Request != null)
+                if (_httpContext != null && _httpContext.Request != null)
                 {
-                    Url = context.Request.Url.PathAndQuery;
-                    HttpMethod = context.Request.HttpMethod;
-                    populateDictionary(context.Request.Form, (key, value) => FormData.Add(key, value));
-                    populateDictionary(context.Request.Headers, (key, value) => Headers.Add(key, value));
+                    Url = _httpContext.Request.Url.PathAndQuery;
+                    HttpMethod = _httpContext.Request.HttpMethod;
+                    populateDictionary(_httpContext.Request.Form, (key, value) => FormData.Add(key, value));
+                    populateDictionary(_httpContext.Request.Headers, (key, value) => Headers.Add(key, value));
                 }
             }
             catch (HttpException)

--- a/src/FubuMVC.Core/Runtime/ISessionState.cs
+++ b/src/FubuMVC.Core/Runtime/ISessionState.cs
@@ -30,11 +30,11 @@ namespace FubuMVC.Core.Runtime
 
     public class SimpleSessionState : ISessionState
     {
-        private readonly HttpSessionState _session;
+        private readonly HttpSessionStateBase _session;
 
-        public SimpleSessionState()
+        public SimpleSessionState(HttpContextBase httpContext)
         {
-            _session = HttpContext.Current.Session;
+            _session = httpContext.Session;
         }
 
         private string getKey<T>()

--- a/src/FubuMVC.Core/SessionState/IFlash.cs
+++ b/src/FubuMVC.Core/SessionState/IFlash.cs
@@ -12,10 +12,17 @@ namespace FubuMVC.Core.SessionState
     public class FlashProvider : IFlash
     {
         public const string FLASH_KEY = "fubuFlash";
-        private HttpSessionStateBase _session;
 
-        public HttpSessionStateBase Session { get { return _session ?? (_session = new HttpSessionStateWrapper(HttpContext.Current.Session)); } set { _session = value; } }
+        public FlashProvider()
+        {
+        }
 
+        public FlashProvider(HttpContextBase httpContext)
+        {
+            Session = httpContext.Session;
+        }
+
+        public HttpSessionStateBase Session { get; set; }
 
         public void Flash(object flashObject)
         {

--- a/src/FubuMVC.Core/Web/Security/WebSecurityContext.cs
+++ b/src/FubuMVC.Core/Web/Security/WebSecurityContext.cs
@@ -6,11 +6,11 @@ namespace FubuMVC.Core.Web.Security
 {
     public class WebSecurityContext : ISecurityContext
     {
-        private readonly HttpContext _context;
+        private readonly HttpContextBase _context;
 
-        public WebSecurityContext()
+        public WebSecurityContext(HttpContextBase httpContext)
         {
-            _context = HttpContext.Current;
+            _context = httpContext;
         }
 
 

--- a/src/FubuMVC.Diagnostics/Core/Infrastructure/HttpRequest.cs
+++ b/src/FubuMVC.Diagnostics/Core/Infrastructure/HttpRequest.cs
@@ -6,9 +6,16 @@ namespace FubuMVC.Diagnostics.Core.Infrastructure
     [MarkedForTermination("Need to get rid of this")]
     public class HttpRequest : IHttpRequest
     {
+        private readonly HttpContextBase _httpContext;
+
+        public HttpRequest(HttpContextBase httpContext)
+        {
+            _httpContext = httpContext;
+        }
+
         public string CurrentUrl()
         {
-            var url = HttpContext.Current.Request.RawUrl;
+            var url = _httpContext.Request.RawUrl;
 			if (url.EndsWith("/"))
 			{
 				url = url.TrimEnd('/');

--- a/src/FubuMVC.HelloWorld/Services/IHttpSession.cs
+++ b/src/FubuMVC.HelloWorld/Services/IHttpSession.cs
@@ -10,15 +10,22 @@ namespace FubuMVC.HelloWorld.Services
 
     public class CurrentHttpContextSession : IHttpSession
     {
+        private readonly HttpContextBase _httpContext;
+
+        public CurrentHttpContextSession(HttpContextBase httpContext)
+        {
+            _httpContext = httpContext;
+        }
+
         public void Clear()
         {
-            HttpContext.Current.Session.Clear();
+            _httpContext.Session.Clear();
         }
 
         public object this[string key]
         {
-            get { return HttpContext.Current.Session [key]; }
-            set { HttpContext.Current.Session[key] = value; }
+            get { return _httpContext.Session [key]; }
+            set { _httpContext.Session[key] = value; }
         }
     }
 }

--- a/src/FubuMVC.Tests/FakeHttpContext.cs
+++ b/src/FubuMVC.Tests/FakeHttpContext.cs
@@ -1,0 +1,9 @@
+﻿using System.Web;
+
+namespace FubuMVC.Tests
+{
+    public class FakeHttpContext : HttpContextBase
+    {
+         
+    }
+}

--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Commands\PackagesCommandTester.cs" />
     <Compile Include="Commands\usage_graph_smoke_tester.cs" />
     <Compile Include="ConnegAttributeTester.cs" />
+    <Compile Include="FakeHttpContext.cs" />
     <Compile Include="FubuApplicationTester.cs" />
     <Compile Include="FubuRegistryWithTypesTester.cs" />
     <Compile Include="Http\AspNet\AspNetCurrentHttpRequestTester.cs" />

--- a/src/FubuMVC.Tests/Registration/Nodes/WebFormRenderTester.cs
+++ b/src/FubuMVC.Tests/Registration/Nodes/WebFormRenderTester.cs
@@ -1,3 +1,4 @@
+using System.Web;
 using FubuCore;
 using FubuMVC.Core;
 using FubuMVC.Core.Behaviors;
@@ -35,6 +36,7 @@ namespace FubuMVC.Tests.Registration.Nodes
                 x.For<IActionBehavior>().Use(new ObjectDefInstance(render.As<IContainerModel>().ToObjectDef(DiagnosticLevel.None)));
                 x.For<IWebFormsControlBuilder>().Use<WebFormsControlBuilder>();
                 x.For<IWebFormRenderer>().Use<WebFormRenderer>();
+                x.For<HttpContextBase>().Use(() => new FakeHttpContext());
                 x.For<IOutputWriter>().Use<OutputWriter>();
                 x.For<IFubuRequest>().Use<InMemoryFubuRequest>();
                 x.For<IPageActivator>().Use<PageActivator>();

--- a/src/FubuMVC.Tests/StructureMapIoC/StructureMapServiceLocatorTester.cs
+++ b/src/FubuMVC.Tests/StructureMapIoC/StructureMapServiceLocatorTester.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Web;
 using FubuMVC.Core.Security;
 using FubuMVC.Core.Web.Security;
 using FubuMVC.StructureMap;
@@ -25,6 +26,7 @@ namespace FubuMVC.Tests.StructureMapIoC
             container = new Container(x =>
             {
                 x.For<ISecurityContext>().Use(_mockSecurityContext);
+                x.For<HttpContextBase>().Use(new FakeHttpContext());
                 x.For<ISecurityContext>().AddInstances(
                     s => s.Type<WebSecurityContext>().Named(_testInstanceKey));
             });

--- a/src/FubuMVC.Tests/StructureMapIoC/when_applying_diagnostics_from_FubuApplication.cs
+++ b/src/FubuMVC.Tests/StructureMapIoC/when_applying_diagnostics_from_FubuApplication.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Web;
 using System.Web.Routing;
 using FubuCore;
 using FubuCore.Binding;
@@ -48,6 +49,8 @@ namespace FubuMVC.Tests.StructureMapIoC
             }))
                 .StructureMap(() => theContainer)
                 .Bootstrap().Routes;            
+            
+            theContainer.Configure(x => x.For<HttpContextBase>().Use(new FakeHttpContext()));
         }
 
 

--- a/src/FubuMVC.WebForms/IWebFormsControlBuilder.cs
+++ b/src/FubuMVC.WebForms/IWebFormsControlBuilder.cs
@@ -16,6 +16,13 @@ namespace FubuMVC.WebForms
     // Untestable ASP.NET code to follow....
     public class WebFormsControlBuilder : IWebFormsControlBuilder
     {
+        private readonly HttpContextBase _httpContext;
+
+        public WebFormsControlBuilder(HttpContextBase httpContext)
+        {
+            _httpContext = httpContext;
+        }
+
         public virtual Control LoadControlFromVirtualPath(string virtualPath, Type mustImplementInterfaceType)
         {
             return (Control) BuildManager.CreateInstanceFromVirtualPath(virtualPath, mustImplementInterfaceType);
@@ -23,7 +30,7 @@ namespace FubuMVC.WebForms
 
         public void ExecuteControl(IHttpHandler handler, TextWriter writer)
         {
-            HttpContext.Current.Server.Execute(handler, writer, true);
+            _httpContext.Server.Execute(handler, writer, true);
         }
     }
 }

--- a/src/FubuMVC.WebForms/WebFormRenderer.cs
+++ b/src/FubuMVC.WebForms/WebFormRenderer.cs
@@ -9,10 +9,12 @@ namespace FubuMVC.WebForms
     public class WebFormRenderer : IWebFormRenderer
     {
         private readonly IOutputWriter _outputWriter;
+        private readonly HttpContextBase _httpContext;
 
-        public WebFormRenderer(IOutputWriter writer)
+        public WebFormRenderer(IOutputWriter writer, HttpContextBase httpContext)
         {
             _outputWriter = writer;
+            _httpContext = httpContext;
         }
 
         public void RenderControl(Control control)
@@ -40,7 +42,7 @@ namespace FubuMVC.WebForms
         public virtual string ExecuteHandler(IHttpHandler handler)
         {
             var writer = new StringWriter();
-            HttpContext.Current.Server.Execute(handler, writer, true);
+            _httpContext.Server.Execute(handler, writer, true);
             writer.Flush();
 
             // See if this can just write out to the buffer


### PR DESCRIPTION
HttpContextBase is now passed through via the container and
provides a safer way to access the context when using
async requests
