### PR TITLE
PartialInvoker.InvokeObject using SetterBinder to model bind incoming input

### DIFF
--- a/src/FubuMVC.Core/Runtime/SetterBinder.cs
+++ b/src/FubuMVC.Core/Runtime/SetterBinder.cs
@@ -1,3 +1,4 @@
+using System;
 using FubuCore.Binding;
 
 namespace FubuMVC.Core.Runtime
@@ -15,12 +16,18 @@ namespace FubuMVC.Core.Runtime
 
         public void BindProperties<T>(T target)
         {
-            _binder.Bind(typeof (T), target, _context);
+            BindProperties(typeof(T), target);
+        }
+
+        public void BindProperties(Type type, object target)
+        {
+            _binder.Bind(type, target, _context);
         }
     }
 
     public interface ISetterBinder
     {
         void BindProperties<T>(T target);
+        void BindProperties(Type type, object target);
     }
 }

--- a/src/FubuMVC.Core/UI/PartialInvoker.cs
+++ b/src/FubuMVC.Core/UI/PartialInvoker.cs
@@ -12,15 +12,17 @@ namespace FubuMVC.Core.UI
         private readonly IAuthorizationPreviewService _authorization;
         private readonly ITypeResolver _types;
         private readonly IOutputWriter _writer;
+        readonly ISetterBinder _setterBinder;
 
         public PartialInvoker(IPartialFactory factory, IFubuRequest request, IAuthorizationPreviewService authorization,
-                              ITypeResolver types, IOutputWriter writer)
+                              ITypeResolver types, IOutputWriter writer, ISetterBinder setterBinder)
         {
             _factory = factory;
             _request = request;
             _authorization = authorization;
             _types = types;
             _writer = writer;
+            _setterBinder = setterBinder;
         }
 
         public string Invoke<T>() where T : class
@@ -40,6 +42,7 @@ namespace FubuMVC.Core.UI
             if (_authorization.IsAuthorized(model))
             {
                 var requestType = _types.ResolveType(model);
+                _setterBinder.BindProperties(requestType, model);
                 _request.Set(requestType, model);
                 output = invokeWrapped(requestType);
             }

--- a/src/FubuMVC.Tests/UI/PartialInvokerTester.cs
+++ b/src/FubuMVC.Tests/UI/PartialInvokerTester.cs
@@ -29,6 +29,9 @@ namespace FubuMVC.Tests.UI
                 .WhenCalled(r => theAction.InvokePartial())
                 .Return(MockFor<IRecordedOutput>());
 
+            MockFor<ISetterBinder>()
+                .Expect(x => x.BindProperties(theInput.GetType(), theInput));
+
             Services.Inject<ITypeResolver>(new TypeResolver());
 
             ClassUnderTest.InvokeObject(theInput);
@@ -62,6 +65,12 @@ namespace FubuMVC.Tests.UI
         public void should_return_recorded_output()
         {
             MockFor<IRecordedOutput>().AssertWasCalled(x => x.GetText());
+        }
+
+        [Test]
+        public void should_bind_properties_on_the_input()
+        {
+            MockFor<ISetterBinder>().VerifyAllExpectations();
         }
     }
 
@@ -176,6 +185,7 @@ namespace FubuMVC.Tests.UI
             MockFor<IFubuRequest>().Stub(x => x.Get<PartialInputModel>()).Return(theInput);
             MockFor<IAuthorizationPreviewService>().Expect(x => x.IsAuthorized(theInput)).Return(false);
             MockFor<IPartialFactory>().Stub(x => x.BuildPartial(typeof(PartialInputModel))).Return(theAction);
+            Services.Inject<ITypeResolver>(new TypeResolver());
 
             theOutput = ClassUnderTest.InvokeObject(theInput);
         }
@@ -203,6 +213,12 @@ namespace FubuMVC.Tests.UI
         public void should_return_empty_result()
         {
             theOutput.ShouldBeEmpty();
+        }
+
+        [Test]
+        public void should_not_bind_properties_on_the_input()
+        {
+            MockFor<ISetterBinder>().AssertWasNotCalled(x => x.BindProperties(theInput.GetType(), theInput));
         }
     }
 


### PR DESCRIPTION
When using this.PartialFor(new InputModel()) we ran into a use case where we still want default model binding behavior to kick in for the models properties.
