### PR TITLE
Added the ability to set the http status description in output writer.

### DIFF
--- a/src/FubuMVC.Core/Diagnostics/HttpStatusReport.cs
+++ b/src/FubuMVC.Core/Diagnostics/HttpStatusReport.cs
@@ -5,6 +5,7 @@ namespace FubuMVC.Core.Diagnostics
 	public class HttpStatusReport : IBehaviorDetails
 	{
 		public HttpStatusCode Status { get; set; }
+        public string Description { get; set; }
 
 		public void AcceptVisitor(IBehaviorDetailsVisitor visitor)
 		{

--- a/src/FubuMVC.Core/Diagnostics/Tracing/RecordingOutputWriter.cs
+++ b/src/FubuMVC.Core/Diagnostics/Tracing/RecordingOutputWriter.cs
@@ -65,12 +65,13 @@ namespace FubuMVC.Core.Diagnostics.Tracing
         }
 
 
-        public override void WriteResponseCode(HttpStatusCode status)
+        public override void WriteResponseCode(HttpStatusCode status, string description = null)
         {
             _report.AddDetails(new HttpStatusReport{
-                Status = status
+                Status = status,
+                Description = description
             });
-            base.WriteResponseCode(status);
+            base.WriteResponseCode(status, description);
         }
 
         public override IRecordedOutput Record(Action action)

--- a/src/FubuMVC.Core/Http/AspNet/AspNetHttpWriter.cs
+++ b/src/FubuMVC.Core/Http/AspNet/AspNetHttpWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Web;
+using FubuCore;
 
 namespace FubuMVC.Core.Http.AspNet
 {
@@ -40,9 +41,10 @@ namespace FubuMVC.Core.Http.AspNet
             _response.Redirect(url, false);
         }
 
-        public void WriteResponseCode(HttpStatusCode status)
+        public void WriteResponseCode(HttpStatusCode status, string description = null)
         {
             _response.StatusCode = (int) status;
+            if (description.IsNotEmpty()) _response.StatusDescription = description;
         }
 
         public void AppendCookie(HttpCookie cookie)

--- a/src/FubuMVC.Core/Http/IHttpWriter.cs
+++ b/src/FubuMVC.Core/Http/IHttpWriter.cs
@@ -13,7 +13,7 @@ namespace FubuMVC.Core.Http
         void WriteContentType(string contentType);
         void Write(string content);
         void Redirect(string url);
-        void WriteResponseCode(HttpStatusCode status);
+        void WriteResponseCode(HttpStatusCode status, string description = null);
         void AppendCookie(HttpCookie cookie);
 
         void Write(Action<Stream> output);
@@ -49,7 +49,7 @@ namespace FubuMVC.Core.Http
             throw new NotImplementedException();
         }
 
-        public void WriteResponseCode(HttpStatusCode status)
+        public void WriteResponseCode(HttpStatusCode status, string description = null)
         {
             throw new NotImplementedException();
         }

--- a/src/FubuMVC.Core/Http/NulloHttpWriter.cs
+++ b/src/FubuMVC.Core/Http/NulloHttpWriter.cs
@@ -28,7 +28,7 @@ namespace FubuMVC.Core.Http
         {
         }
 
-        public void WriteResponseCode(HttpStatusCode status)
+        public void WriteResponseCode(HttpStatusCode status, string description = null)
         {
         }
 

--- a/src/FubuMVC.Core/Runtime/IOutputWriter.cs
+++ b/src/FubuMVC.Core/Runtime/IOutputWriter.cs
@@ -17,7 +17,7 @@ namespace FubuMVC.Core.Runtime
 
         void Write(string contentType, Action<Stream> output);
 
-        void WriteResponseCode(HttpStatusCode status);
+        void WriteResponseCode(HttpStatusCode status, string description = null);
         IRecordedOutput Record(Action action);
         void Replay(IRecordedOutput output);
     }

--- a/src/FubuMVC.Core/Runtime/InMemoryOutputWriter.cs
+++ b/src/FubuMVC.Core/Runtime/InMemoryOutputWriter.cs
@@ -68,7 +68,7 @@ namespace FubuMVC.Core.Runtime
             output(_output);
         }
 
-        public void WriteResponseCode(HttpStatusCode status)
+        public void WriteResponseCode(HttpStatusCode status, string description = null)
         {
         }
 

--- a/src/FubuMVC.Core/Runtime/OutputWriter.cs
+++ b/src/FubuMVC.Core/Runtime/OutputWriter.cs
@@ -94,9 +94,9 @@ namespace FubuMVC.Core.Runtime
             CurrentState.Write(contentType, output);
         }
 
-        public virtual void WriteResponseCode(HttpStatusCode status)
+        public virtual void WriteResponseCode(HttpStatusCode status, string description = null)
         {
-            Writer.WriteResponseCode(status);
+            Writer.WriteResponseCode(status, description);
         }
     }
 }

--- a/src/FubuMVC.OwinHost.Testing/FubuMVC.OwinHost.Testing.csproj
+++ b/src/FubuMVC.OwinHost.Testing/FubuMVC.OwinHost.Testing.csproj
@@ -76,6 +76,8 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="OwnResponseTester.cs" />
+    <Compile Include="OwnHttpWriterTester.cs" />
     <Compile Include="FormRequestReaderTester.cs" />
     <Compile Include="OwinAggregateDictionaryTester.cs" />
     <Compile Include="OwnCurrentHttpRequestTester.cs" />

--- a/src/FubuMVC.OwinHost.Testing/OwnHttpWriterTester.cs
+++ b/src/FubuMVC.OwinHost.Testing/OwnHttpWriterTester.cs
@@ -1,0 +1,37 @@
+﻿using System.Net;
+using FubuCore;
+using NUnit.Framework;
+using FubuTestingSupport;
+
+namespace FubuMVC.OwinHost.Testing
+{
+    [TestFixture]
+    public class OwnHttpWriterTester
+    {
+        private Response response;
+        private OwinHttpWriter writer;
+
+        [SetUp]
+        protected void beforeEach()
+        {
+            response = new Response(null);
+            writer = new OwinHttpWriter(response);
+        }
+
+        [Test]
+        public void should_set_response_code()
+        {
+            writer.WriteResponseCode(HttpStatusCode.UseProxy);
+
+            response.Status.ShouldEqual("305");
+        }
+
+        [Test]
+        public void should_set_response_code_and_description()
+        {
+            const string description = "why u no make good request?";
+            writer.WriteResponseCode(HttpStatusCode.BadRequest, description);
+            response.Status.ShouldEqual("400 {0}".ToFormat(description));
+        }
+    }
+}

--- a/src/FubuMVC.OwinHost.Testing/OwnResponseTester.cs
+++ b/src/FubuMVC.OwinHost.Testing/OwnResponseTester.cs
@@ -1,0 +1,32 @@
+﻿using System.Net;
+using NUnit.Framework;
+using FubuTestingSupport;
+
+namespace FubuMVC.OwinHost.Testing
+{
+    [TestFixture]
+    public class OwnResponseTester
+    {
+        private Response response;
+
+        [SetUp]
+        protected void beforeEach()
+        {
+            response = new Response(null);
+        }
+
+        [Test]
+        public void should_render_response_status_only()
+        {
+            response.SetStatus(HttpStatusCode.InternalServerError);
+            response.Status.ShouldEqual("500");
+        }
+
+        [Test]
+        public void should_render_response_status_and_description()
+        {
+            response.SetStatus(HttpStatusCode.NotAcceptable, "your mom goes to college");
+            response.Status.ShouldEqual("406 your mom goes to college");
+        }
+    }
+}

--- a/src/FubuMVC.OwinHost/FubuOwinHost.cs
+++ b/src/FubuMVC.OwinHost/FubuOwinHost.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,7 +95,7 @@ namespace FubuMVC.OwinHost
 
         private static void write500(Response response, Exception ex)
         {
-            response.Status = "500";
+            response.SetStatus(HttpStatusCode.InternalServerError);
             response.Write("FubuMVC has detected an exception\r\n");
             response.Write(ex.ToString());
         }
@@ -107,7 +108,7 @@ namespace FubuMVC.OwinHost
 
         private static void write404(Response response)
         {
-            response.Status = "404";
+            response.SetStatus(HttpStatusCode.NotFound);
             response.Write("Sorry, I can't find this resource");
         }
     }
@@ -123,9 +124,16 @@ namespace FubuMVC.OwinHost
         {
             _result = result;
 
-            Status = "200 OK";
+            SetStatus(HttpStatusCode.OK, "OK");
             Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             Encoding = Encoding.UTF8;
+        }
+
+        public Response SetStatus(HttpStatusCode statusCode, string description = null)
+        {
+            var status = statusCode.As<int>().ToString();
+            Status = description.IsEmpty() ? status : "{0} {1}".ToFormat(status, description);
+            return this;
         }
 
         public string Status { get; set; }

--- a/src/FubuMVC.OwinHost/OwinHttpWriter.cs
+++ b/src/FubuMVC.OwinHost/OwinHttpWriter.cs
@@ -48,14 +48,14 @@ namespace FubuMVC.OwinHost
         public void Redirect(string url)
         {
             // TODO: This is a hack, better way to accomplish this?
-            _response.Status = Convert.ToString((int)HttpStatusCode.Redirect);
+            _response.SetStatus(HttpStatusCode.Redirect);
             _response.Headers.Add("Location", url);
             _response.Write(string.Format("<html><head><title>302 Found</title></head><body><h1>Found</h1><p>The document has moved <a href='{0}'>here</a>.</p></body></html>", url));
         }
 
-        public void WriteResponseCode(HttpStatusCode status)
+        public void WriteResponseCode(HttpStatusCode status, string description = null)
         {
-            _response.Status = status.As<int>().ToString();
+            _response.SetStatus(status, description);
         }
 
         public void AppendCookie(HttpCookie cookie)

--- a/src/FubuMVC.Tests/Diagnostics/RecordingOutputWriterTester.cs
+++ b/src/FubuMVC.Tests/Diagnostics/RecordingOutputWriterTester.cs
@@ -103,6 +103,18 @@ namespace FubuMVC.Tests.Diagnostics
 				.AssertWasCalled(w => w.WriteResponseCode(HttpStatusCode.Unauthorized));
 		}
 
+        [Test]
+        public void write_response_code_and_description()
+        {
+            const string description = "why u no make good request?";
+            ClassUnderTest.WriteResponseCode(HttpStatusCode.BadRequest, description);
+            MockFor<IDebugReport>()
+                .AssertWasCalled(x => x.AddDetails(new HttpStatusReport { Status = HttpStatusCode.BadRequest, Description = description }));
+
+            MockFor<IHttpWriter>()
+                .AssertWasCalled(w => w.WriteResponseCode(HttpStatusCode.BadRequest, description));
+        }
+
 		[Test]
 		public void write_cookie()
 		{

--- a/src/FubuMVC.Tests/FubuRegistryImportingTester.cs
+++ b/src/FubuMVC.Tests/FubuRegistryImportingTester.cs
@@ -208,7 +208,7 @@ namespace FubuMVC.Tests
                 throw new NotImplementedException();
             }
 
-            public void WriteResponseCode(HttpStatusCode status)
+            public void WriteResponseCode(HttpStatusCode status, string description = null)
             {
                 throw new NotImplementedException();
             }

--- a/src/FubuMVC.Tests/Runtime/OutputWriterTester.cs
+++ b/src/FubuMVC.Tests/Runtime/OutputWriterTester.cs
@@ -47,6 +47,14 @@ namespace FubuMVC.Tests.Runtime
         }
 
         [Test]
+        public void write_response_code_and_description_delegates()
+        {
+            const string description = "why u no make good request?";
+            ClassUnderTest.WriteResponseCode(HttpStatusCode.BadRequest, description);
+            theHttpWriter.AssertWasCalled(x => x.WriteResponseCode(HttpStatusCode.BadRequest, description));
+        }
+
+        [Test]
         public void write_by_stream_delegates_to_the_http_writer_in_normal_mode()
         {
             Action<Stream> action = stream => { };


### PR DESCRIPTION
I'm interested in using the http status description to return informative error messages from our RESTful services. Currently fubu only allows you to set the status code. This pull request adds an optional status description parameter to the IOutputWriter.WriteResponseCode method.
