### PR TITLE
Fixed an nre in the FileSystemVirtualPathProvider

### DIFF
--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Localization\RegisterXmlDirectoryLocalizationStorageTester.cs" />
     <Compile Include="Localization\SpinUpLocalizationCachesTester.cs" />
     <Compile Include="Packaging\ContentOnlyPackageInfoTester.cs" />
+    <Compile Include="Packaging\FileSystemVirtualPathProviderTester.cs" />
     <Compile Include="ProcessFactoryTester.cs" />
     <Compile Include="ProcessWrapperTester.cs" />
     <Compile Include="Registration\ActionMethodFilterTester.cs" />

--- a/src/FubuMVC.Tests/Packaging/FileSystemVirtualPathProviderTester.cs
+++ b/src/FubuMVC.Tests/Packaging/FileSystemVirtualPathProviderTester.cs
@@ -1,0 +1,17 @@
+using FubuMVC.Core.Packaging.VirtualPaths;
+using NUnit.Framework;
+
+namespace FubuMVC.Tests.Packaging
+{
+    [TestFixture]
+    public class FileSystemVirtualPathProviderTester
+    {
+        [Test]
+        public void should_return_false_when_file_name_contains_invalid_characters()
+        {
+            var pathProvider = new FileSystemVirtualPathProvider();
+            pathProvider.RegisterContentDirectory("/yada");
+            pathProvider.FileExists("/yada\"");
+        }
+    }
+}


### PR DESCRIPTION
The FileSystemVirtualPathProvider.FileExists method currently throws an nre when the path contains invalid characters. This ends up causing the server to return a 500 instead of a 404 and blows up our logs with unhandled exceptions. I changed it to simply return false if the path contains any of these characters.
