### PR TITLE
adding pdf '/content/documents' support

### DIFF
--- a/src/FubuMVC.Core/Assets/Files/AssetFolder.cs
+++ b/src/FubuMVC.Core/Assets/Files/AssetFolder.cs
@@ -4,6 +4,7 @@ namespace FubuMVC.Core.Assets.Files
     {
         images,
         scripts,
-        styles
+        styles,
+        documents
     }
 }

--- a/src/FubuMVC.Core/Runtime/MimeType.cs
+++ b/src/FubuMVC.Core/Runtime/MimeType.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
@@ -33,6 +32,7 @@ namespace FubuMVC.Core.Runtime
         public static readonly MimeType Jpg = New("image/jpeg", ".jpg", ".jpeg").Folder(AssetFolder.images);
         public static readonly MimeType Bmp = New("image/bmp", ".bmp", ".bm").Folder(AssetFolder.images);
         public static readonly MimeType Unknown = New("dunno");
+        public static readonly MimeType Pdf = New("application/pdf",".pdf").Folder(AssetFolder.documents);
 
 
         private readonly IList<string> _extensions = new List<string>();


### PR DESCRIPTION
Ryan and I were talking today about how it would be nice if we could extend the Fubu notion of 'content' folder. Specifically we were discussing the ability to add 'pdf' support and eventually 'fonts' as well now that you can embed those in the page as well. 

While dinking around in the code, I noticed that the MimeType could be extended, but that the folders were a locked down 'enum'.

This commit just highlights a few areas where i did some exploring, and this pull request is really a starting point for a conversation around supporting an extensible 'content' folder.

cheers,
-d
