### PR TITLE
Added precompile step to make a blank CommonAssemblyInfo.cs file

### DIFF
--- a/src/FubuMVC.Core/FubuMVC.Core.csproj
+++ b/src/FubuMVC.Core/FubuMVC.Core.csproj
@@ -720,6 +720,9 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>if not exist $(SolutionDir)\CommonAssemblyInfo.cs copy NUL $(SolutionDir)\CommonAssemblyInfo.cs</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Get rid of the annoying step of having to create the CommonAssemblyInfo.cs file. This precompile step creates it.
