### PR TITLE
Fix PackageFacility base directory parsing

### DIFF
--- a/src/FubuMVC.Core/Packaging/FubuMvcPackageFacility.cs
+++ b/src/FubuMVC.Core/Packaging/FubuMvcPackageFacility.cs
@@ -60,7 +60,7 @@ namespace FubuMVC.Core.Packaging
 
         private static string determineApplicationPathFromAppDomain()
         {
-			var basePath = AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            var basePath = AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
             if (basePath.EndsWith("bin"))
             {
                 basePath = basePath.Substring(0, basePath.Length - 3).TrimEnd(Path.DirectorySeparatorChar);


### PR DESCRIPTION
Hi,

We had a problem with FubuMVC where it's looking for bottles in different place depending on weather I run NUnit tests from Visual Studio or directly through NUnit. Turns out AppDomain.CurrentDomain.BaseDirectory sometimes ends with a slash and sometimes doesn't. Which was not accounted for in FubuMvcPackageFacitlity.cs function determineApplicationPathFromAppDomain. 
So there, I fixed it :)

Let me know if I should do something differently.

Cheers,
Rytis
