### PR TITLE
Fix PackageFacility domain base directory parsing

### DIFF
--- a/src/FubuMVC.Core/Packaging/FubuMvcPackageFacility.cs
+++ b/src/FubuMVC.Core/Packaging/FubuMvcPackageFacility.cs
@@ -60,7 +60,7 @@ namespace FubuMVC.Core.Packaging
 
         private static string determineApplicationPathFromAppDomain()
         {
-            var basePath = AppDomain.CurrentDomain.BaseDirectory;
+            var basePath = AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
             if (basePath.EndsWith("bin"))
             {
                 basePath = basePath.Substring(0, basePath.Length - 3).TrimEnd(Path.DirectorySeparatorChar);


### PR DESCRIPTION
Hi,

We had a problem with FubuMVC with loading bottles. It was looking for bottles in different place depending if I run test from inside Visual Studio or directly using NUnit. That was because AppDomain.CurrentDomain.BaseDirecotry in some cases ends with a slash. That was not accounted for in FubuMvcPackageFacility.cs method determineApplicationPathFromAppDomain. 
So there, I fixed it :)
Verified that it fixes our problem.

Let me know if it's not good enough.

Cheers,
Rytis
