### PR TITLE
Introduced WarmUpSetsForCombinationPolicy to fill the combinations cache at startup.

### DIFF
--- a/src/FubuMVC.Core/Assets/AssetGraph.cs
+++ b/src/FubuMVC.Core/Assets/AssetGraph.cs
@@ -196,6 +196,12 @@ namespace FubuMVC.Core.Assets
             return (IFileDependency) ObjectFor(name);
         }
 
+
+        public void ForEachSetName(Action<string> action)
+        {
+            _sets.GetAllKeys().Each(action);
+        }
+
         #region Nested type: AssetFilesKey
 
         public class AssetFilesKey

--- a/src/FubuMVC.Core/Assets/WarmUpSetsForCombinationPolicy.cs
+++ b/src/FubuMVC.Core/Assets/WarmUpSetsForCombinationPolicy.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using Bottles.Diagnostics;
+using FubuMVC.Core.Assets.Files;
+using FubuMVC.Core.Runtime;
+
+namespace FubuMVC.Core.Assets
+{
+    public class WarmUpSetsForCombinationPolicy : IAssetPolicy
+    {
+        private readonly IAssetTagPlanCache _planCache;
+        private readonly IAssetDependencyFinder _finder;
+
+        public WarmUpSetsForCombinationPolicy(IAssetTagPlanCache planCache, IAssetDependencyFinder finder)
+        {
+            _planCache = planCache;
+            _finder = finder;
+        }
+
+        public void Apply(IPackageLog log, IAssetPipeline pipeline, AssetGraph graph)
+        {
+            graph.ForEachSetName(WarmUpSet);
+        }
+
+        public void WarmUpSet(string name)
+        {
+            var dependencies = _finder.CompileDependenciesAndOrder(new[] {name}).ToList();
+            if (dependencies.Count == 0)
+            {
+                return;
+            }
+            var mimeType = MimeType.MimeTypeByFileName(dependencies[0]);
+            _planCache.PlanFor(mimeType, dependencies);
+        }
+
+    }
+}

--- a/src/FubuMVC.Core/FubuMVC.Core.csproj
+++ b/src/FubuMVC.Core/FubuMVC.Core.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Assets\Http\AssetEtagInvocationFilter.cs" />
     <Compile Include="Assets\Http\AssetWriter.cs" />
     <Compile Include="Assets\RecordingAssetRegistration.cs" />
+    <Compile Include="Assets\WarmUpSetsForCombinationPolicy.cs" />
     <Compile Include="Behaviors\AsyncContinueWithBehavior.cs" />
     <Compile Include="Behaviors\AsyncInterceptExceptionBehavior.cs" />
     <Compile Include="Behaviors\Conditional\ConditionalBehavior.cs" />

--- a/src/FubuMVC.Core/Registration/DSL/AssetsExpression.cs
+++ b/src/FubuMVC.Core/Registration/DSL/AssetsExpression.cs
@@ -93,6 +93,7 @@ namespace FubuMVC.Core.Registration.DSL
         public AssetsExpression CombineAllUniqueAssetRequests()
         {
             setService<ICombinationDeterminationService, CombineAllUniqueSetsCombinationDeterminationService>();
+            addService<IAssetPolicy, WarmUpSetsForCombinationPolicy>();
             return this;
         }
 

--- a/src/FubuMVC.Tests/Assets/AssetExpressionUsageTester.cs
+++ b/src/FubuMVC.Tests/Assets/AssetExpressionUsageTester.cs
@@ -218,6 +218,15 @@ crud includes a.js, b.js, c.js
         }
 
         [Test]
+        public void adds_a_warm_up_policy_for_asset_combinations()
+        {
+            var registry = new FubuRegistry();
+            registry.Assets.CombineAllUniqueAssetRequests();
+
+            registry.BuildGraph().Services.ServicesFor<IAssetPolicy>()
+                .ShouldContain(x => x.Type == typeof(WarmUpSetsForCombinationPolicy));
+        }
+        [Test]
         public void register_a_combination_policy_with_CombineWith()
         {
             var registry = new FubuRegistry();

--- a/src/FubuMVC.Tests/Assets/AssetGraphTester.cs
+++ b/src/FubuMVC.Tests/Assets/AssetGraphTester.cs
@@ -245,6 +245,21 @@ namespace FubuMVC.Tests.Assets
             ScriptNamesFor("b", "before-b").ShouldHaveTheSameElementsAs("before-b", "b");
             ScriptNamesFor("before-b").ShouldHaveTheSameElementsAs("before-b");
         }
+
+        [Test]
+        public void sets_names()
+        {
+            theGraph.AddToSet("setA", "a-1.js");
+            theGraph.AddToSet("setA", "a-2.js");
+            theGraph.AddToSet("setB", "b-1.js");
+            theGraph.AddToSet("setB", "b-2.js");
+
+            var sets = new List<string>();
+            theGraph.ForEachSetName(sets.Add);
+
+            sets.ShouldEqual(new[] {"setA", "setB"});
+        }
+
     }
 
     [TestFixture]

--- a/src/FubuMVC.Tests/Assets/WarmUpSetsForCombinationPolicyTester.cs
+++ b/src/FubuMVC.Tests/Assets/WarmUpSetsForCombinationPolicyTester.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using FubuMVC.Core.Assets;
+using FubuMVC.Core.Runtime;
+using FubuTestingSupport;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace FubuMVC.Tests.Assets
+{
+    [TestFixture]
+    public class WarmUpSetsForCombinationPolicyTester : InteractionContext<WarmUpSetsForCombinationPolicy>
+    {
+        private AssetGraph _graph;
+        private IEnumerable<string> _assetsForSetA;
+        private IEnumerable<string> _assetsForSetB;
+
+        protected override void beforeEach()
+        {
+            _graph = new AssetGraph();
+
+            _assetsForSetA = new[] { "a-1.js", "a-2.js" };
+            _assetsForSetB = new[] { "b-1.css", "b-2.css" };
+
+            _assetsForSetA.Each(x => _graph.AddToSet("setA", x));
+            _assetsForSetB.Each(x => _graph.AddToSet("setB", x));
+
+            _graph.CompileDependencies(null);
+            MockFor<IAssetDependencyFinder>()
+                .Stub(x => x.CompileDependenciesAndOrder(new[] { "setA" }))
+                .Return(_assetsForSetA);
+            MockFor<IAssetDependencyFinder>()
+                .Stub(x => x.CompileDependenciesAndOrder(new[] { "setB" }))
+                .Return(_assetsForSetB);
+
+            ClassUnderTest.Apply(null, null, _graph);
+        }
+
+        [Test]
+        public void plans_for_sets_are_generated()
+        {
+            MockFor<IAssetTagPlanCache>().AssertWasCalled(x => x.PlanFor(MimeType.Javascript, _assetsForSetA));
+            MockFor<IAssetTagPlanCache>().AssertWasCalled(x => x.PlanFor(MimeType.Css, _assetsForSetB));
+        }
+    }
+}

--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Assets\Content\TransformationPolicyComparerTester.cs" />
     <Compile Include="Assets\Content\TransformerPolicyLibraryTester.cs" />
     <Compile Include="Assets\Content\TransformerPolicyTester.cs" />
+    <Compile Include="Assets\WarmUpSetsForCombinationPolicyTester.cs" />
     <Compile Include="Behaviors\AsyncContinueWithBehaviorTests.cs" />
     <Compile Include="Behaviors\AsyncInterceptExceptionBehaviorTester.cs" />
     <Compile Include="Behaviors\BasicBehaviorTester.cs" />


### PR DESCRIPTION
To reproduce this issue, you can take a look at this working sample:
https://github.com/emiaj/FubuAssetCombinationIssue
The "master" branch reproduce the issue when you click on the hardcoded links targeting the combined sets (site-scripts and site-styles).

If you checkout the "custom-fubu" branch, you will notice that when clicking those hardcoded links the problem is gone.

The problem relies on depending on the IFubuPage asset related methods (WriteCssTags, WriteScriptTags) to populate the combination cache, thus, there are scenarios where the app recycles itself just after the view has been delivered, and that causes the following exception:

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
No combination or asset file exists with the name ....

So the idea is to proactively populate this cache at least for asset sets at startup when CombineAllUniqueAssetRequests is specified.
