### PR TITLE
Fix for authorization policies getting RightsFor() called multiple times

### DIFF
--- a/src/FubuMVC.Core/Diagnostics/Tracing/RecordingAuthorizationPolicyExecutor.cs
+++ b/src/FubuMVC.Core/Diagnostics/Tracing/RecordingAuthorizationPolicyExecutor.cs
@@ -16,18 +16,18 @@ namespace FubuMVC.Core.Diagnostics.Tracing
 
         public override AuthorizationRight IsAuthorized(IFubuRequest request, IEnumerable<IAuthorizationPolicy> policies)
         {
-            var decision = base.IsAuthorized(request, policies);
-            if (policies.Any())
+            var authorizationReport = new AuthorizationReport();
+
+            var decision = IsAuthorized(request, policies, (policy, right) =>
+                                                                    {
+                                                                        authorizationReport.AddVote(policy.ToString(), right.Name);
+                                                                    });
+            if (authorizationReport.Details.Any())
             {
-                var authorizationReport = new AuthorizationReport();
-                policies.Each(p =>
-                {
-                    var rights = p.RightsFor(request);
-                    authorizationReport.AddVote(p.ToString(), rights.Name);
-                });
                 authorizationReport.Decision = decision.Name;
                 _report.AddDetails(authorizationReport);
             }
+
             return decision;
         }
     }

--- a/src/FubuMVC.Core/Security/AuthorizationRight.cs
+++ b/src/FubuMVC.Core/Security/AuthorizationRight.cs
@@ -31,12 +31,14 @@ namespace FubuMVC.Core.Security
 
         public static AuthorizationRight Combine(IEnumerable<AuthorizationRight> rights)
         {
-            if (!rights.Any())
+            var authorizationRights = rights.ToArray();
+
+            if (!authorizationRights.Any())
             {
                 return AuthorizationRight.None;
             }
 
-            return rights.OrderBy(x => x.Precedence).First(); 
+            return authorizationRights.OrderBy(x => x.Precedence).First(); 
         }
 
         public static AuthorizationRight CombineRights(params AuthorizationRight[] rights)

--- a/src/FubuMVC.Tests/Security/AuthorizationPolicyExecutorTester.cs
+++ b/src/FubuMVC.Tests/Security/AuthorizationPolicyExecutorTester.cs
@@ -1,4 +1,6 @@
-﻿using FubuMVC.Core.Runtime;
+﻿using FubuMVC.Core.Diagnostics;
+using FubuMVC.Core.Diagnostics.Tracing;
+using FubuMVC.Core.Runtime;
 using FubuMVC.Core.Security;
 using FubuTestingSupport;
 using NUnit.Framework;
@@ -14,18 +16,17 @@ namespace FubuMVC.Tests.Security
 
         protected override void beforeEach()
         {
-
             var request = MockFor<IFubuRequest>();
 
             policies = Services.CreateMockArrayFor<IAuthorizationPolicy>(3);
-            policies[0].Stub(x => x.RightsFor(request)).Return(AuthorizationRight.Allow);
-            policies[1].Stub(x => x.RightsFor(request)).Return(AuthorizationRight.None);
-            policies[2].Stub(x => x.RightsFor(request)).Return(AuthorizationRight.None);
+            policies[0].Expect(x => x.RightsFor(request)).Return(AuthorizationRight.Allow).Repeat.Once();
+            policies[1].Expect(x => x.RightsFor(request)).Return(AuthorizationRight.None).Repeat.Once();
+            policies[2].Expect(x => x.RightsFor(request)).Return(AuthorizationRight.None).Repeat.Once();
             _answer = ClassUnderTest.IsAuthorized(request, policies);
         }
 
         [Test]
-        public void should_query_all_authorization_policies()
+        public void should_query_all_authorization_policies_once()
         {
             policies[0].VerifyAllExpectations();
             policies[1].VerifyAllExpectations();
@@ -38,4 +39,71 @@ namespace FubuMVC.Tests.Security
             _answer.ShouldEqual(AuthorizationRight.Allow);
         }
     }
+
+
+    [TestFixture]
+    public class when_executing_recording_authorization_policies : InteractionContext<RecordingAuthorizationPolicyExecutor>
+    {
+        private IAuthorizationPolicy[] policies;
+        private AuthorizationRight _answer;
+
+        protected override void beforeEach()
+        {
+            var request = MockFor<IFubuRequest>();
+
+            policies = Services.CreateMockArrayFor<IAuthorizationPolicy>(3);
+            policies[0].Expect(x => x.RightsFor(request)).Return(AuthorizationRight.Allow).Repeat.Once();
+            policies[1].Expect(x => x.RightsFor(request)).Return(AuthorizationRight.None).Repeat.Once();
+            policies[2].Expect(x => x.RightsFor(request)).Return(AuthorizationRight.None).Repeat.Once();
+            _answer = ClassUnderTest.IsAuthorized(request, policies);
+        }
+
+        [Test]
+        public void should_query_all_authorization_policies_once()
+        {
+            policies[0].VerifyAllExpectations();
+            policies[1].VerifyAllExpectations();
+            policies[2].VerifyAllExpectations();
+        }
+
+        [Test]
+        public void should_return_the_combined_result_of_all_policies()
+        {
+            _answer.ShouldEqual(AuthorizationRight.Allow);
+        }
+
+        [Test]
+        public void should_add_debug_report_details()
+        {
+            MockFor<IDebugReport>().AssertWasCalled(a => a.AddDetails(null), x => x.IgnoreArguments());
+        }
+    }
+
+    [TestFixture]
+    public class when_executing_recording_authorization_with_no_policies : InteractionContext<RecordingAuthorizationPolicyExecutor>
+    {
+        private AuthorizationRight _answer;
+
+        protected override void beforeEach()
+        {
+            var request = MockFor<IFubuRequest>();
+
+            var policies = Services.CreateMockArrayFor<IAuthorizationPolicy>(0);
+            _answer = ClassUnderTest.IsAuthorized(request, policies);
+        }
+
+        [Test]
+        public void should_return_the_combined_result_of_all_policies()
+        {
+            _answer.ShouldEqual(AuthorizationRight.None);
+        }
+
+        [Test]
+        public void should_add_debug_report_details()
+        {
+            MockFor<IDebugReport>().AssertWasNotCalled(a => a.AddDetails(null), x => x.IgnoreArguments());
+        }
+
+    }
+
 }


### PR DESCRIPTION
Fixed two instances where authorization policies were having their RightsFor() methods getting called multiple times. 
1. The AuthorizationRight.Combine was enumerating the rights enumeration multiple times.
2. The recording authorization policy always called policy RightsFor twice, once for the base class evaluation and then again to record it.

Multiple users have seen this issue in the wild with it being especially painful when it is causing data access to be being done repeatedly.
