### PR TITLE
Don't create more than one behavior chain for the same action call.

### DIFF
--- a/src/FubuMVC.Core/Registration/BehaviorAggregator.cs
+++ b/src/FubuMVC.Core/Registration/BehaviorAggregator.cs
@@ -19,6 +19,7 @@ namespace FubuMVC.Core.Registration
         {
             _sources
                 .SelectMany(src => src.FindActions(_types))
+				.Distinct()
                 .Each(call =>
                           {
                               var chain = new BehaviorChain();


### PR DESCRIPTION
With more than one action source that matches the same action based on different criteria, should not create more than one behavior chain.
