### PR TITLE
adding support for Spark 1.7's .shade files

### DIFF
--- a/fubuTemplates/default/src/FUBUPROJECTNAME/packages.config
+++ b/fubuTemplates/default/src/FUBUPROJECTNAME/packages.config
@@ -7,7 +7,7 @@
   <package id="FubuMVC.References" version="0.9.1.651" />
   <package id="FubuMVC.Spark" version="0.9.1.656" />
   <package id="HtmlTags" version="1.0.0.51" />
-  <package id="Spark" version="1.6" />
+  <package id="Spark" version="1.7" />
   <package id="structuremap" version="2.6.3" />
   <package id="WebActivator" version="1.5" />
 </packages>

--- a/src/FubuMVC.Spark.Tests/FubuMVC.Spark.Tests.csproj
+++ b/src/FubuMVC.Spark.Tests/FubuMVC.Spark.Tests.csproj
@@ -58,8 +58,9 @@
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6\lib\Rhino.Mocks.dll</HintPath>
     </Reference>
-    <Reference Include="Spark">
-      <HintPath>..\packages\Spark.1.6\lib\NET40\Spark.dll</HintPath>
+    <Reference Include="Spark, Version=1.7.0.0, Culture=neutral, PublicKeyToken=7f8549eed921a12c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Spark.1.7.0.0\lib\NET40\Spark.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap">
       <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>

--- a/src/FubuMVC.Spark.Tests/SparkModel/Scanning/ScanRequestTester.cs
+++ b/src/FubuMVC.Spark.Tests/SparkModel/Scanning/ScanRequestTester.cs
@@ -23,6 +23,7 @@ namespace FubuMVC.Spark.Tests.SparkModel.Scanning
         {
             ClassUnderTest.IncludeSparkViews();
             ClassUnderTest.Filters.ShouldContain("*{0}".ToFormat(Constants.DotSpark));
+            ClassUnderTest.Filters.ShouldContain("*{0}".ToFormat(Constants.DotShade));
         }
 
         [Test]
@@ -34,8 +35,8 @@ namespace FubuMVC.Spark.Tests.SparkModel.Scanning
         [Test]
         public void include_puts_the_filter_into_the_filters_expression()
         {
-            new[] { "*.spark", "*.view", "*.template" }.Each(ClassUnderTest.Include);
-            ClassUnderTest.Filters.ShouldEqual("*.spark;*.view;*.template");
+            new[] { "*.spark", "*.shade", "*.view", "*.template" }.Each(ClassUnderTest.Include);
+            ClassUnderTest.Filters.ShouldEqual("*.spark;*.shade;*.view;*.template");
         }
 
         [Test]

--- a/src/FubuMVC.Spark.Tests/packages.config
+++ b/src/FubuMVC.Spark.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="HtmlTags" version="1.1.0.71" />
   <package id="NUnit" version="2.5.10.11092" />
   <package id="RhinoMocks" version="3.6" />
-  <package id="Spark" version="1.6" />
+  <package id="Spark" version="1.7" />
   <package id="structuremap" version="2.6.3" />
   <package id="structuremap.automocking" version="2.6.3" />
 </packages>

--- a/src/FubuMVC.Spark/FubuMVC.Spark.csproj
+++ b/src/FubuMVC.Spark/FubuMVC.Spark.csproj
@@ -40,9 +40,9 @@
     <Reference Include="HtmlTags">
       <HintPath>..\packages\HtmlTags.1.1.0.71\lib\4.0\HtmlTags.dll</HintPath>
     </Reference>
-    <Reference Include="Spark, Version=1.6.0.0, Culture=neutral, PublicKeyToken=7f8549eed921a12c, processorArchitecture=MSIL">
+    <Reference Include="Spark, Version=1.7.0.0, Culture=neutral, PublicKeyToken=7f8549eed921a12c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Spark.1.6\lib\NET40\Spark.dll</HintPath>
+      <HintPath>..\packages\Spark.1.7.0.0\lib\NET40\Spark.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FubuMVC.Spark/ITemplateFinderConvention.cs
+++ b/src/FubuMVC.Spark/ITemplateFinderConvention.cs
@@ -10,6 +10,7 @@ namespace FubuMVC.Spark
         public void Configure(TemplateFinder<Template> finder)
         {
             finder.IncludeFile("*spark");
+            finder.IncludeFile("*shade");
             // TODO: This is not automatically synched with what the attacher looks for.
             finder.IncludeFile("bindings.xml");
 

--- a/src/FubuMVC.Spark/SparkModel/Scanning/ScanRequestExtensions.cs
+++ b/src/FubuMVC.Spark/SparkModel/Scanning/ScanRequestExtensions.cs
@@ -6,10 +6,12 @@ namespace FubuMVC.Spark.SparkModel.Scanning
 {
 	public static class ScanRequestExtensions
 	{
-        public static void IncludeSparkViews(this ScanRequest request)
+		public static void IncludeSparkViews(this ScanRequest request)
 		{
-			var pattern = "*{0}".ToFormat(Constants.DotSpark);
-			request.Include(pattern);
-        }
-    }
+			var dotSparkPattern = "*{0}".ToFormat(Constants.DotSpark);
+			request.Include(dotSparkPattern);
+			var dotShadePattern = "*{0}".ToFormat(Constants.DotShade);
+			request.Include(dotShadePattern);
+		}
+	}
 }

--- a/src/FubuMVC.Spark/SparkModel/TemplateExtensions.cs
+++ b/src/FubuMVC.Spark/SparkModel/TemplateExtensions.cs
@@ -8,7 +8,7 @@ namespace FubuMVC.Spark.SparkModel
     {
         public static bool IsSparkView(this ITemplate template)
 		{
-            return Path.GetExtension(template.FilePath).EqualsIgnoreCase(Constants.DotSpark);
+            return Path.GetExtension(template.FilePath).EqualsIgnoreCase(Constants.DotSpark) || Path.GetExtension(template.FilePath).EqualsIgnoreCase(Constants.DotShade);
         }
 
         public static bool IsXml(this ITemplate template)

--- a/src/FubuMVC.Spark/packages.config
+++ b/src/FubuMVC.Spark/packages.config
@@ -3,5 +3,5 @@
   <package id="Bottles" version="0.9.1.278" />
   <package id="FubuCore" version="0.9.9.151" />
   <package id="HtmlTags" version="1.1.0.71" />
-  <package id="Spark" version="1.6" />
+  <package id="Spark" version="1.7" />
 </packages>

--- a/src/KayakTestApplication/packages.config
+++ b/src/KayakTestApplication/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FubuCore" version="0.9.9.151" />
-  <package id="Spark" version="1.6" />
+  <package id="Spark" version="1.7" />
   <package id="structuremap" version="2.6.3" />
 </packages>

--- a/src/QuickStart/packages.config
+++ b/src/QuickStart/packages.config
@@ -4,7 +4,7 @@
   <package id="FubuCore" version="0.9.9.151" />
   <package id="FubuLocalization" version="0.9.5.43" />
   <package id="HtmlTags" version="1.1.0.71" />
-  <package id="Spark" version="1.6" />
+  <package id="Spark" version="1.7" />
   <package id="structuremap" version="2.6.3" />
   <package id="WebActivator" version="1.5" />
 </packages>

--- a/src/TestPackage4/packages.config
+++ b/src/TestPackage4/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FubuCore" version="0.9.9.151" />
-  <package id="Spark" version="1.6" />
+  <package id="Spark" version="1.7" />
 </packages>


### PR DESCRIPTION
I only scanned the contributor guide, so flame me if I did something wrong and I'll fix it.

I ran `rake compile test` and everything passes. I tested with just .spark views, just .shade views, and a mix of the two. I only updated the unit tests in the scanner, since most of the other unit tests use Spark types that work with both types of templates, and therefore I'm not sure what value there is in adding a bunch of .shade variants. Please let me know what additional unit test changes you think are appropriate and I'll add them.

@jeremydmiller mentioned he has some big E2E test changes coming, and that this PR should wait till after Monday. That's fine with me; I'll wait to hear from y'all what changes I should make in that regard.
