### PR TITLE
Added description to contextual actions

### DIFF
--- a/src/FubuMVC.Core/UI/Navigation/AuthorizedContextualMenu.cs
+++ b/src/FubuMVC.Core/UI/Navigation/AuthorizedContextualMenu.cs
@@ -24,6 +24,7 @@ namespace FubuMVC.Core.UI.Navigation
                 Key = definition.Key,
                 MenuItemState = menuItemState,
                 Text = definition.Text(),
+				Description = definition.Description(),
                 Url = endpoint.Url
             };
         }

--- a/src/FubuMVC.Core/UI/Navigation/IContextualAction.cs
+++ b/src/FubuMVC.Core/UI/Navigation/IContextualAction.cs
@@ -6,6 +6,7 @@
         string Category { get; }
         MenuItemState UnauthorizedState { get; }
         string Text();
+		string Description();
         MenuItemState IsAvailable(T target);
         Endpoint FindEndpoint(IEndpointService endpoints, T target);
     }

--- a/src/FubuMVC.Core/UI/Navigation/MenuItemToken.cs
+++ b/src/FubuMVC.Core/UI/Navigation/MenuItemToken.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace FubuMVC.Core.UI.Navigation
 {
@@ -22,6 +21,7 @@ namespace FubuMVC.Core.UI.Navigation
         public string Key { get; set; }
         public string Text { get; set; }
         public string Url { get; set; }
+		public string Description { get; set; }
         public MenuItemState MenuItemState { get; set; }
 
         public string IconUrl { get; set; }
@@ -55,7 +55,7 @@ namespace FubuMVC.Core.UI.Navigation
 
         public override string ToString()
         {
-            return string.Format("Key: {0}, Text: {1}, Url: {2}, MenuItemState: {3}", Key, Text, Url, MenuItemState);
+            return string.Format("Key: {0}, Text: {1}, Url: {2}, MenuItemState: {3} Description: {4}", Key, Text, Url, MenuItemState, Description);
         }
     }
 }

--- a/src/FubuMVC.Core/UI/Navigation/NavigationService.cs
+++ b/src/FubuMVC.Core/UI/Navigation/NavigationService.cs
@@ -35,7 +35,7 @@ namespace FubuMVC.Core.UI.Navigation
         // TODO -- this could really use some more end to end testing
         public MenuItemToken BuildToken(MenuNode node)
         {
-            var token = new MenuItemToken{
+            var token = new MenuItemToken {
                 Children = node.Children.Select(BuildToken).ToArray(),
                 Key = node.Key.Key,
                 Text = node.Key.ToString(),

--- a/src/FubuMVC.Tests/UI/Navigation/AuthorizedContextualMenuTester.cs
+++ b/src/FubuMVC.Tests/UI/Navigation/AuthorizedContextualMenuTester.cs
@@ -1,10 +1,8 @@
-using System;
 using FubuMVC.Core;
 using FubuMVC.Core.UI.Navigation;
 using FubuTestingSupport;
 using NUnit.Framework;
 using Rhino.Mocks;
-using FubuCore;
 
 namespace FubuMVC.Tests.UI.Navigation
 {
@@ -12,11 +10,12 @@ namespace FubuMVC.Tests.UI.Navigation
     public class AuthorizedContextualMenuTester : InteractionContext<AuthorizedContextualMenu<ContextualObject>>
     {
         private IContextualAction<ContextualObject> definition;
-        private string theCategory = "the category";
-        private string theTextOfTheMenuItem = "menu text";
-        private string theUrl = "the url";
-        private string theKey = "the key";
-        private ContextualObject theTarget;
+    	private const string theCategory = "the category";
+    	private const string theTextOfTheMenuItem = "menu text";
+		private const string theDescriptionOfTheMenuItem = "menu item description";
+    	private const string theUrl = "the url";
+    	private const string theKey = "the key";
+    	private ContextualObject theTarget;
 
         protected override void beforeEach()
         {
@@ -27,7 +26,8 @@ namespace FubuMVC.Tests.UI.Navigation
 
             definition.Stub(x => x.Category).Return(theCategory);
             definition.Stub(x => x.Text()).Return(theTextOfTheMenuItem);
-            definition.Stub(x => x.Key).Return(theKey);
+			definition.Stub(x => x.Description()).Return(theDescriptionOfTheMenuItem);
+			definition.Stub(x => x.Key).Return(theKey);
         }
 
         private bool WouldBeAuthorized
@@ -89,6 +89,15 @@ namespace FubuMVC.Tests.UI.Navigation
 
             theResultingMenuItemToken.Text.ShouldEqual(theTextOfTheMenuItem);
         }
+
+		[Test]
+		public void should_get_the_description_from_the_inner_definition()
+		{
+			WouldBeAuthorized = true;
+			AvailabilityAsDeterminedByTheStrategyIs = MenuItemState.Available;
+
+			theResultingMenuItemToken.Description.ShouldEqual(theDescriptionOfTheMenuItem);
+		}
 
         [Test]
         public void should_get_the_url_from_the_inner_definition()
@@ -152,42 +161,5 @@ namespace FubuMVC.Tests.UI.Navigation
     public class ContextualObject
     {
         public string Name { get; set; }
-    }
-
-    public class StubContextualMenu : IContextualAction<ContextualObject>
-    {
-        public string Key
-        {
-            get; set;
-        }
-
-        public string Category
-        {
-            get;
-            set;
-        }
-
-        public MenuItemState UnauthorizedState
-        {
-            get { return MenuItemState.Hidden; }
-        }
-
-        public string Text()
-        {
-            return "{0}/{1}".ToFormat(Category, Key);
-        }
-
-        public MenuItemState IsAvailable(ContextualObject target)
-        {
-            return MenuItemState.Available;
-        }
-
-        public Endpoint FindEndpoint(IEndpointService endpoints, ContextualObject target)
-        {
-            return new Endpoint(){
-                IsAuthorized = true,
-                Url = Text()
-            };
-        }
     }
 }


### PR DESCRIPTION
Contextual actions are used to help define menu items and their availability. What if we need to communicate to the user what the menu item is for or why exactly the menu item is disabled.
#### Usage

These will likely be used in the title attribute of the DOM element created by the consumer of the menu item. 

``` html
<li>
<a href="/cases/1/dispatch" class="disabled" title="You cannot dispatch a case you do not own.">Dispatch</a>
</li>
```
#### Cavet

This is an interface change so it means work for users of fubumvc that implement IContextualActions<T>.
