### PR TITLE
Propagating menu item category into the MenuItemToken

### DIFF
--- a/src/FubuMVC.Core/UI/Navigation/AuthorizedContextualMenu.cs
+++ b/src/FubuMVC.Core/UI/Navigation/AuthorizedContextualMenu.cs
@@ -24,6 +24,7 @@ namespace FubuMVC.Core.UI.Navigation
                 Key = definition.Key,
                 MenuItemState = menuItemState,
                 Text = definition.Text(),
+				Category = definition.Category,
 				Description = definition.Description(),
                 Url = endpoint.Url
             };

--- a/src/FubuMVC.Core/UI/Navigation/MenuItemToken.cs
+++ b/src/FubuMVC.Core/UI/Navigation/MenuItemToken.cs
@@ -22,6 +22,7 @@ namespace FubuMVC.Core.UI.Navigation
         public string Text { get; set; }
         public string Url { get; set; }
 		public string Description { get; set; }
+		public string Category { get; set; }
         public MenuItemState MenuItemState { get; set; }
 
         public string IconUrl { get; set; }

--- a/src/FubuMVC.Tests/UI/Navigation/AuthorizedContextualMenuTester.cs
+++ b/src/FubuMVC.Tests/UI/Navigation/AuthorizedContextualMenuTester.cs
@@ -99,6 +99,15 @@ namespace FubuMVC.Tests.UI.Navigation
 			theResultingMenuItemToken.Description.ShouldEqual(theDescriptionOfTheMenuItem);
 		}
 
+		[Test]
+		public void should_get_the_category_from_the_inner_definition()
+		{
+			WouldBeAuthorized = true;
+			AvailabilityAsDeterminedByTheStrategyIs = MenuItemState.Available;
+
+			theResultingMenuItemToken.Category.ShouldEqual(theCategory);
+		}
+
         [Test]
         public void should_get_the_url_from_the_inner_definition()
         {


### PR DESCRIPTION
Category would be nice to have around when consuming menu item tokens. My use case would be that client side I'll have a view that consumes current menu items. Having categories available would assist in the slicing and dicing of the menu rendering.
