### PR TITLE
HttpHeader Binding case-sensitivity

### DIFF
--- a/src/FubuMVC.Tests/AjaxExtensionsTester.cs
+++ b/src/FubuMVC.Tests/AjaxExtensionsTester.cs
@@ -25,17 +25,5 @@ namespace FubuMVC.Tests
             _nonAjaxRequestInput.IsAjaxRequest().ShouldBeFalse();
         }
 
-        [Test]
-        public void x()
-        {
-            var collection = new NameValueCollection();
-            collection.Add("x-requested-with","XMLHttpRequest");
-            collection["X-Requested-With"].ShouldEqual("XMLHttpRequest");
-
-
-            var requestData = new RequestData();
-            requestData.AddValues(new FlatValueSource<object>(new SimpleKeyValues(key => collection[key],() => collection.AllKeys)));
-            requestData.IsAjaxRequest().ShouldBeTrue();
-        }
     }
 }

--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Behaviors\Chrome\ChromeAttributeTester.cs" />
     <Compile Include="Behaviors\Chrome\ChromeNodeTester.cs" />
     <Compile Include="ConfigurationGraph_DetermineConfigurationType_Tester.cs" />
+    <Compile Include="Http\AspNet\SimpleKeyValueTester.cs" />
     <Compile Include="Registration\default_action_discovery.cs" />
     <Compile Include="Runtime\Dates\DateTimeFormatting_import_integration_testing.cs" />
     <Compile Include="Runtime\Dates\DateTimeToUtcConverterFamilyTester.cs" />

--- a/src/FubuMVC.Tests/Http/AspNet/SimpleKeyValueTester.cs
+++ b/src/FubuMVC.Tests/Http/AspNet/SimpleKeyValueTester.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FubuMVC.Core.Http.AspNet;
+using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuMVC.Tests.Http.AspNet
+{
+    [TestFixture]
+    public class SimpleKeyValueTester
+    {
+         
+        private IDictionary<string, object> _ajaxRequestInput = new Dictionary<string, object> { { "X-Requested-With", "XMLHttpRequest" } };
+        
+        [Test]
+        public void should_default_to_simple_contains()
+        {
+            var skv = new SimpleKeyValues((key) => _ajaxRequestInput[key], () => _ajaxRequestInput.Select(kvp => kvp.Key));
+
+            skv.Has("X-Requested-With").ShouldBeTrue();
+            skv.Has("x-requested-with").ShouldBeFalse();
+
+        }
+        [Test]
+        public void should_use_custom_compare()
+        {
+            var skv = new SimpleKeyValues((key) => _ajaxRequestInput[key], () => _ajaxRequestInput.Select(kvp => kvp.Key), (key,keys) => keys.Contains(key,StringComparer.InvariantCultureIgnoreCase));
+
+            skv.Has("X-Requested-With").ShouldBeTrue();
+            skv.Has("x-requested-with").ShouldBeTrue();
+
+        }
+    }
+}


### PR DESCRIPTION
HttpHeaders in IE are set all lowercase which causes IsAjaxRequest to always return false
