### PR TITLE
Updated asset reader to support aliases in combinations

### DIFF
--- a/src/FubuMVC.Core/Assets/AssetDslReader.cs
+++ b/src/FubuMVC.Core/Assets/AssetDslReader.cs
@@ -158,12 +158,6 @@ namespace FubuMVC.Core.Assets
 
             var comboName = tokens.Dequeue();
 
-            var hasMultipleMimetypes = assets.Select(x => MimeType.MimeTypeByFileName(x)).Distinct().Count() > 1;
-            if (hasMultipleMimetypes)
-            {
-                throw new InvalidSyntaxException("All members of a combination must be of the same type (script or stylesheet)");
-            }
-
             assets.Each(x => _registration.AddToCombination(comboName, x));
         }
 

--- a/src/FubuMVC.Tests/Assets/AssetDslReaderTester.cs
+++ b/src/FubuMVC.Tests/Assets/AssetDslReaderTester.cs
@@ -223,14 +223,5 @@ namespace FubuMVC.Tests.Assets
                 ClassUnderTest.ReadLine("combine a.js,b.js,c.js as");
             });
         }
-
-        [Test]
-        public void combine_without_combo_with_mixed_mimetypes_throws()
-        {
-            Exception<InvalidSyntaxException>.ShouldBeThrownBy(() =>
-            {
-                ClassUnderTest.ReadLine("combine a.js,b.css,c.js as combo1");
-            }).Message.ShouldContain("All members of a combination must be of the same type (script or stylesheet)");
-        }
     }
 }

--- a/src/FubuMVC.Tests/Assets/AssetGraphTester.cs
+++ b/src/FubuMVC.Tests/Assets/AssetGraphTester.cs
@@ -54,7 +54,35 @@ namespace FubuMVC.Tests.Assets
 
             theGraph.AddToCombination("c3", "b.js,c.js,d.js");
             theGraph.NamesForCombination("c3").ShouldHaveTheSameElementsAs("b.js", "c.js", "d.js");
+        }
 
+        [Test]
+        public void add_to_combination_should_unalias_names()
+        {
+            theGraph.Alias("a.js", "a");
+            theGraph.Alias("b.js", "b");
+
+            theGraph.AddToCombination("c1", "a,b,c.js");
+
+            theGraph.NamesForCombination("c1").ShouldHaveTheSameElementsAs("a.js", "b.js", "c.js");
+        }
+
+        [Test]
+        public void add_to_combination_should_throw_when_combination_does_not_already_exist_and_names_for_more_than_one_mime_type()
+        {
+            theGraph.Alias("b.css", "b");
+
+            Exception<InvalidOperationException>.ShouldBeThrownBy(() => theGraph.AddToCombination("c1", "a.js,b"));
+        }
+
+        [Test]
+        public void add_to_combination_should_throw_when_combination_already_exists_and_names_for_do_not_all_match_mime_type()
+        {
+            theGraph.AddToCombination("c1", "a.js");
+            
+            theGraph.Alias("b.css", "b");
+
+            Exception<InvalidOperationException>.ShouldBeThrownBy(() => theGraph.AddToCombination("c1", "b,c.js"));
         }
 
         [Test]


### PR DESCRIPTION
This should close issue 318.  However, I'm having issues testing this in the browser. I'll file a follow-up issue for that problem.
