### PR TITLE
If client sends no accept header at all, treat it as Accept:*/*

### DIFF
--- a/src/FubuMVC.Core/Http/CurrentMimeType.cs
+++ b/src/FubuMVC.Core/Http/CurrentMimeType.cs
@@ -45,7 +45,7 @@ namespace FubuMVC.Core.Http
 
         public bool AcceptsAny()
         {
-            return AcceptTypes.Contains("*/*");
+            return AcceptTypes.DefaultIfEmpty("*/*").Contains("*/*");
         }
 
         public string SelectFirstMatching(IEnumerable<string> candidates)

--- a/src/FubuMVC.Core/Http/MimeTypeList.cs
+++ b/src/FubuMVC.Core/Http/MimeTypeList.cs
@@ -20,7 +20,10 @@ namespace FubuMVC.Core.Http
                 mimeType.ToDelimitedArray(',').Each(x =>
                 {
                     var type = x.Split(';').First();
-                    _mimeTypes.Add(type);
+                    if (type.IsNotEmpty())
+                    {
+                        _mimeTypes.Add(type);
+                    }
                 });
             }
         }

--- a/src/FubuMVC.Tests/Http/CurrentMimeTypeTester.cs
+++ b/src/FubuMVC.Tests/Http/CurrentMimeTypeTester.cs
@@ -50,6 +50,24 @@ namespace FubuMVC.Tests.Http
         }
 
         [Test]
+        public void accepts_any_if_no_accept_header_specified()
+        {
+            new CurrentMimeType("application/x-www-form-urlencoded; charset=UTF-8", null).AcceptsAny().ShouldBeTrue();
+        }
+
+        [Test]
+        public void accepts_any_if_accept_header_is_all_spaces()
+        {
+            new CurrentMimeType("application/x-www-form-urlencoded; charset=UTF-8", "  ").AcceptsAny().ShouldBeTrue();
+        }
+
+        [Test]
+        public void accepts_any_if_accept_header_is_empty()
+        {
+            new CurrentMimeType("application/x-www-form-urlencoded; charset=UTF-8", string.Empty).AcceptsAny().ShouldBeTrue();
+        }
+
+        [Test]
         public void select_first_matching_no_matches()
         {
             new CurrentMimeType("application/x-www-form-urlencoded; charset=UTF-8", "text/html")

--- a/src/FubuMVC.Tests/Http/MimeTypeListTester.cs
+++ b/src/FubuMVC.Tests/Http/MimeTypeListTester.cs
@@ -47,5 +47,26 @@ namespace FubuMVC.Tests.Http
             list.Matches("weird").ShouldBeFalse();
             list.Matches("weird", "wrong").ShouldBeFalse();
         }
+
+        [Test]
+        public void should_ignore_null()
+        {
+            var list = new MimeTypeList((string)null);
+            list.ShouldHaveCount(0);
+        }
+
+        [Test]
+        public void should_ignore_empty_string()
+        {
+            var list = new MimeTypeList(string.Empty);
+            list.ShouldHaveCount(0);
+        }
+
+        [Test]
+        public void should_ignore_whitespace_only_string()
+        {
+            var list = new MimeTypeList("    ");
+            list.ShouldHaveCount(0);
+        }
     }
 }


### PR DESCRIPTION
Also added tests for empty, all whitespace, and null Accept headers
