### PR TITLE
Using the RequestUri in ToFullUrl so urls aren't generated with localhost

### DIFF
--- a/src/FubuMVC.SelfHost/SelfHostCurrentHttpRequest.cs
+++ b/src/FubuMVC.SelfHost/SelfHostCurrentHttpRequest.cs
@@ -1,21 +1,17 @@
 using System;
 using System.Net.Http;
-using System.Web.Http.SelfHost;
 using FubuMVC.Core;
 using FubuMVC.Core.Http;
-using FubuCore;
 
 namespace FubuMVC.SelfHost
 {
     public class SelfHostCurrentHttpRequest : ICurrentHttpRequest
     {
         private readonly HttpRequestMessage _request;
-        private readonly HttpSelfHostConfiguration _configuration;
 
-        public SelfHostCurrentHttpRequest(HttpRequestMessage request, HttpSelfHostConfiguration configuration)
+        public SelfHostCurrentHttpRequest(HttpRequestMessage request)
         {
             _request = request;
-            _configuration = configuration;
         }
 
         public string RawUrl()
@@ -35,7 +31,7 @@ namespace FubuMVC.SelfHost
 
         public string ToFullUrl(string url)
         {
-            return url.ToAbsoluteUrl(_configuration.BaseAddress.OriginalString);
+            return url.ToAbsoluteUrl(_request.RequestUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
         }
 
         public string HttpMethod()

--- a/src/FubuMVC.SelfHost/SelfHostHttpMessageHandler.cs
+++ b/src/FubuMVC.SelfHost/SelfHostHttpMessageHandler.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Http.SelfHost;
 using System.Web.Routing;
 using FubuCore;
 using FubuMVC.Core;
@@ -15,13 +14,11 @@ namespace FubuMVC.SelfHost
     public class SelfHostHttpMessageHandler : HttpMessageHandler
     {
         private readonly FubuRuntime _runtime;
-        private readonly HttpSelfHostConfiguration _configuration;
         private readonly RouteCollection _routes;
 
-        public SelfHostHttpMessageHandler(FubuRuntime runtime, HttpSelfHostConfiguration configuration)
+        public SelfHostHttpMessageHandler(FubuRuntime runtime)
         {
             _runtime = runtime;
-            _configuration = configuration;
 
             _routes = new RouteCollection();
             _routes.AddRange(runtime.Routes);
@@ -57,7 +54,7 @@ namespace FubuMVC.SelfHost
                 try
                 {
                     var response = new HttpResponseMessage(HttpStatusCode.OK);
-                    var arguments = new SelfHostServiceArguments(routeData, request, response, _configuration);
+                    var arguments = new SelfHostServiceArguments(routeData, request, response);
                     var invoker = routeData.RouteHandler.As<FubuRouteHandler>().Invoker;
                     invoker.Invoke(arguments, routeData.Values);
 

--- a/src/FubuMVC.SelfHost/SelfHostHttpServer.cs
+++ b/src/FubuMVC.SelfHost/SelfHostHttpServer.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Web.Http.SelfHost;
-using System.Web.Routing;
 using FubuCore;
 using FubuMVC.Core;
 using FubuMVC.Core.Packaging;
@@ -81,7 +79,7 @@ namespace FubuMVC.SelfHost
 
             FubuMvcPackageFacility.PhysicalRootPath = rootDirectory;
 
-            _server = new HttpSelfHostServer(_configuration, new SelfHostHttpMessageHandler(runtime, _configuration){
+            _server = new HttpSelfHostServer(_configuration, new SelfHostHttpMessageHandler(runtime){
                 Verbose = Verbose
             });
 

--- a/src/FubuMVC.SelfHost/SelfHostServiceArguments.cs
+++ b/src/FubuMVC.SelfHost/SelfHostServiceArguments.cs
@@ -1,5 +1,4 @@
 using System.Net.Http;
-using System.Web.Http.SelfHost;
 using System.Web.Routing;
 using FubuCore.Binding;
 using FubuMVC.Core.Http;
@@ -10,13 +9,13 @@ namespace FubuMVC.SelfHost
     {
         private readonly SelfHostHttpWriter _writer;
 
-        public SelfHostServiceArguments(RouteData routeData, HttpRequestMessage request, HttpResponseMessage response, HttpSelfHostConfiguration configuration)
+        public SelfHostServiceArguments(RouteData routeData, HttpRequestMessage request, HttpResponseMessage response)
         {
             With(request);
             With(response);
 
             With<IRequestData>(new SelfHostRequestData(routeData, request));
-            With<ICurrentHttpRequest>(new SelfHostCurrentHttpRequest(request, configuration));
+            With<ICurrentHttpRequest>(new SelfHostCurrentHttpRequest(request));
             With<IStreamingData>(new SelfHostStreamingData(request));
             _writer = new SelfHostHttpWriter(response);
             With<IHttpWriter>(_writer);


### PR DESCRIPTION
Now you can navigate to the self-hosted fubu application through a different address rather than only http://localhost.
