### PR TITLE
Cookie Binding

### DIFF
--- a/src/FubuMVC.Core/Http/AspNet/AspNetRequestData.cs
+++ b/src/FubuMVC.Core/Http/AspNet/AspNetRequestData.cs
@@ -31,9 +31,13 @@ namespace FubuMVC.Core.Http.AspNet
             var files = request.Files;
             addValues(RequestDataSource.File, key => files[key], () => files.AllKeys);
 
-            addValues(RequestDataSource.Header, key => request.Headers[key], () => request.Headers.AllKeys,(key,keys) => keys.Contains(key, StringComparer.InvariantCultureIgnoreCase));
+            Func<string, IEnumerable<string>, bool> ignoreCaseKeyFinder = (key, keys) => keys.Contains(key, StringComparer.InvariantCultureIgnoreCase);
 
-            AddValues(new RequestPropertyValueSource(context.HttpContext.Request));
+            addValues(RequestDataSource.Header, key => request.Headers[key], () => request.Headers.AllKeys, ignoreCaseKeyFinder);
+
+            AddValues(new RequestPropertyValueSource(request));
+
+            addValues(RequestDataSource.Cookie, key => request.Cookies[key].Value, () => request.Cookies.AllKeys, ignoreCaseKeyFinder);
         }
 
 

--- a/src/FubuMVC.Core/Http/RequestDataSource.cs
+++ b/src/FubuMVC.Core/Http/RequestDataSource.cs
@@ -7,6 +7,7 @@ namespace FubuMVC.Core.Http
         RequestProperty,
         File,
         Header,
+        Cookie,
         Other
     }
 }

--- a/src/FubuMVC.SelfHost.Testing/FubuMVC.SelfHost.Testing.csproj
+++ b/src/FubuMVC.SelfHost.Testing/FubuMVC.SelfHost.Testing.csproj
@@ -95,6 +95,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="binding_against_request_cookies.cs" />
     <Compile Include="reading_cookies.cs" />
     <Compile Include="SelfHostCookiesTester.cs" />
     <Compile Include="binding_against_form_data.cs" />

--- a/src/FubuMVC.SelfHost.Testing/SelfHostCookiesTester.cs
+++ b/src/FubuMVC.SelfHost.Testing/SelfHostCookiesTester.cs
@@ -47,6 +47,22 @@ namespace FubuMVC.SelfHost.Testing
         }
 
         [Test]
+        public void gets_the_cookie_with_multiple_cookie_states()
+        {
+            theMessage.Headers.Add("Cookie", "TestCookie=Hello;AnotherCookie=Goodbye");
+            ClassUnderTest.Get("TestCookie").ShouldNotBeNull();
+            ClassUnderTest.Get("AnotherCookie").ShouldNotBeNull();
+        }
+
+        [Test]
+        public void gets_the_cookie_with_multiple_cookie_states_with_name_value_pairs()
+        {
+            theMessage.Headers.Add("Cookie", "TestCookie=a1=b1&a2=b2;AnotherCookie=y1=z1&y2=z2");
+            ClassUnderTest.Get("TestCookie").ShouldNotBeNull().Values.AllKeys.ShouldHaveTheSameElementsAs("a1", "a2");
+            ClassUnderTest.Get("AnotherCookie").ShouldNotBeNull().Values.AllKeys.ShouldHaveTheSameElementsAs("y1", "y2");
+        }
+
+        [Test]
         public void get_just_returns_null_if_nothing_is_found()
         {
             ClassUnderTest.Get("TestCookie").ShouldBeNull();
@@ -57,82 +73,6 @@ namespace FubuMVC.SelfHost.Testing
         {
             theResponse.Headers.Add("Cookie", "TestCookie=Hello");
             ClassUnderTest.Response.Single().Name.ShouldEqual("TestCookie");
-        }
-    }
-
-    [TestFixture]
-    public class determining_the_name_of_a_CookieHeaderValue
-    {
-        [Test]
-        public void name_for_a_single_cookie_state()
-        {
-            var value = new CookieHeaderValue("Test", "Value");
-            SelfHostCookies.DetermineName(value).ShouldEqual("Test");
-        }
-
-        [Test]
-        public void throws_when_no_cookie_state_is_found()
-        {
-            var value = new CookieHeaderValue("Test", "Value");
-            value.Cookies.Clear();
-
-            Exception<ArgumentException>
-                .ShouldBeThrownBy(() =>SelfHostCookies.DetermineName(value));
-        }
-
-        [Test]
-        public void name_for_multiple_cookie_states()
-        {
-            var theValues = new NameValueCollection();
-            theValues.Add("x", "aaa");
-            theValues.Add("y", "bbb");
-
-            var value = new CookieHeaderValue("Test", theValues);
-            
-            SelfHostCookies.DetermineName(value).ShouldEqual("Test");
-        }
-    }
-
-    [TestFixture]
-    public class determining_the_value_of_a_CookieHeaderValue
-    {
-        [Test]
-        public void value_for_a_single_cookie_state()
-        {
-            var value = new CookieHeaderValue("Test", "Value");
-            var cookie = new HttpCookie("Test");
-
-            SelfHostCookies.FillValues(value, cookie);
-
-            cookie.Value.ShouldEqual("Value");
-        }
-
-        [Test]
-        public void throws_when_no_cookie_state_is_found()
-        {
-            var value = new CookieHeaderValue("Test", "Value");
-            value.Cookies.Clear();
-
-            var cookie = new HttpCookie("Test");
-
-            Exception<ArgumentException>
-                .ShouldBeThrownBy(() => SelfHostCookies.FillValues(value, cookie));
-        }
-
-        [Test]
-        public void values_for_multiple_cookie_states()
-        {
-            var theValues = new NameValueCollection();
-            theValues.Add("x", "aaa");
-            theValues.Add("y", "bbb");
-
-            var value = new CookieHeaderValue("Test", theValues);
-            var cookie = new HttpCookie("Test");
-
-            SelfHostCookies.FillValues(value, cookie);
-
-            cookie.Values["x"].ShouldEqual("aaa");
-            cookie.Values["y"].ShouldEqual("bbb");
         }
     }
 }

--- a/src/FubuMVC.SelfHost.Testing/binding_against_request_cookies.cs
+++ b/src/FubuMVC.SelfHost.Testing/binding_against_request_cookies.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuMVC.SelfHost.Testing
+{
+    [TestFixture]
+    public class binding_against_request_cookies
+    {
+        [Test]
+        public void can_bind_to_request_cookies()
+        {
+            var model = new CookieModel{
+                Color = "Green",
+                Direction = "South"
+            };
+
+            SelfHostHarness.Endpoints.GetByInput(model, configure: SetupCookies).ReadAsText()
+                .ShouldEqual(model.ToString());
+        }
+
+        public void SetupCookies(HttpWebRequest request)
+        {
+            //request.Headers[HttpRequestHeader.Cookie] = "Color=Green;Direction=South";
+            request.CookieContainer.Add(new Cookie("Color", "Green", "/", "localhost"));
+            request.CookieContainer.Add(new Cookie("Direction", "South", "/", "localhost"));
+        }
+    }
+
+    public class CookieBindingEndpoint
+    {
+        public string get_cookie_data(CookieModel input)
+        {
+            return input.ToString();
+        }
+    }
+
+    public class CookieModel
+    {
+        public string Color { get; set; }
+        public string Direction { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("Color: {0}, Direction: {1}", Color, Direction);
+        }
+    }
+}

--- a/src/FubuMVC.SelfHost/SelfHostRequestData.cs
+++ b/src/FubuMVC.SelfHost/SelfHostRequestData.cs
@@ -9,12 +9,13 @@ using FubuCore.Binding.Values;
 using FubuCore.Util;
 using FubuMVC.Core.Http;
 using System.Linq;
+using FubuMVC.Core.Http.AspNet;
 
 namespace FubuMVC.SelfHost
 {
     public class SelfHostRequestData : RequestData
     {
-        public SelfHostRequestData(RouteData routeData, HttpRequestMessage request)
+        public SelfHostRequestData(RouteData routeData, HttpRequestMessage request, ICookies cookies)
         {
             AddValues(new RouteDataValues(routeData));
 
@@ -30,6 +31,12 @@ namespace FubuMVC.SelfHost
             var headers = AggregateKeyValues.For(new HeaderKeyValues(request.Headers),
                                                  new HeaderKeyValues(request.Content.Headers));
             AddValues(RequestDataSource.Header.ToString(), headers);
+
+            Func<string, IEnumerable<string>, bool> ignoreCaseKeyFinder = (key, keys) => keys.Contains(key, StringComparer.InvariantCultureIgnoreCase);
+            var values = new SimpleKeyValues(key => cookies.Get(key).Value, () => cookies.Request.Select(x => x.Name), ignoreCaseKeyFinder);
+            var valueSource = new FlatValueSource<object>(values, RequestDataSource.Cookie.ToString());
+
+            AddValues(valueSource);
         }
     }
 

--- a/src/FubuMVC.SelfHost/SelfHostServiceArguments.cs
+++ b/src/FubuMVC.SelfHost/SelfHostServiceArguments.cs
@@ -14,13 +14,14 @@ namespace FubuMVC.SelfHost
             With(request);
             With(response);
 
-            With<IRequestData>(new SelfHostRequestData(routeData, request));
+            var cookies = new SelfHostCookies(request, response);
+            With<IRequestData>(new SelfHostRequestData(routeData, request, cookies));
             With<ICurrentHttpRequest>(new SelfHostCurrentHttpRequest(request));
             With<IStreamingData>(new SelfHostStreamingData(request));
             _writer = new SelfHostHttpWriter(response);
             With<IHttpWriter>(_writer);
             With<IClientConnectivity>(new SelfHostClientConnectivity());
-            With<ICookies>(new SelfHostCookies(request, response));
+            With<ICookies>(cookies);
             With<IResponse>(new SelfHostResponse(response));
         }
 


### PR DESCRIPTION
Added Cookies back as a value source in AspNetRequestData, also added it to SelfHostRequestData with a few slight changes to how SelfHostCookies works based on problems I was running into while writing the binding_against_request_cookies test. Several of the unit tests around CookieHeaderValue no longer seemed relevant after some of the changes I made so I got rid of them, but I would like to hear others feedback on that to see if I have missed something.
