### PR TITLE
A few attribute fixes

### DIFF
--- a/src/FubuMVC.Core/Registration/Conventions/AsyncContinueWithHandlerConvention.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/AsyncContinueWithHandlerConvention.cs
@@ -7,7 +7,6 @@ using FubuMVC.Core.Registration.Nodes;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Description("Adds the necessary behaviors to a chain for asynchronous Behavior Chain's that contain an action that returns a Task")]
     public class AsyncContinueWithHandlerConvention : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Registration/Conventions/AttachInputPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/AttachInputPolicy.cs
@@ -4,7 +4,6 @@ using System.Linq;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Description("Attaches the InputNode to a BehaviorChain if there are any readers registered")]
     public class AttachInputPolicy : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Registration/Conventions/AttachOutputPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/AttachOutputPolicy.cs
@@ -7,7 +7,6 @@ using FubuMVC.Core.Continuations;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Description("Attaches the OutputNode to a BehaviorChain if there are any output writers registered to the node")]
     public class AttachOutputPolicy : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Registration/Conventions/ContinuationHandlerConvention.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/ContinuationHandlerConvention.cs
@@ -7,7 +7,6 @@ using FubuMVC.Core.Registration.Nodes;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Description("Add a ContinuationNode behind any ActionFilter or ActionCall that returns a FubuContinuation")]
     public class ContinuationHandlerConvention : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Registration/Conventions/DefaultOutputPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/DefaultOutputPolicy.cs
@@ -5,7 +5,6 @@ using FubuMVC.Core.Resources.Conneg;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     public class DefaultOutputPolicy : Policy
     {
         public DefaultOutputPolicy()

--- a/src/FubuMVC.Core/Registration/Conventions/DictionaryOutputConvention.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/DictionaryOutputConvention.cs
@@ -6,7 +6,6 @@ using FubuMVC.Core.Resources.Conneg;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     public class DictionaryOutputConvention : Policy
     {
         public DictionaryOutputConvention()

--- a/src/FubuMVC.Core/Registration/Conventions/HtmlTagOutputPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/HtmlTagOutputPolicy.cs
@@ -5,7 +5,6 @@ using FubuCore;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     public class HtmlTagOutputPolicy : Policy
     {
         public HtmlTagOutputPolicy()

--- a/src/FubuMVC.Core/Registration/Conventions/JsonMessageInputConvention.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/JsonMessageInputConvention.cs
@@ -5,7 +5,6 @@ using FubuMVC.Core.Resources.Conneg;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     public class JsonMessageInputConvention : Policy
     {
         public JsonMessageInputConvention()

--- a/src/FubuMVC.Core/Registration/Conventions/MissingRouteInputPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/MissingRouteInputPolicy.cs
@@ -4,7 +4,6 @@ using FubuCore.Descriptions;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Title("Modifies the RouteDefinition of a Route to reflect the Input Type properties")]
     public class MissingRouteInputPolicy : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Registration/Conventions/ModifyChainAttributeConvention.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/ModifyChainAttributeConvention.cs
@@ -5,7 +5,6 @@ using FubuMVC.Core.Registration.Nodes;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Description("Applies modifications to an ActionCall from any attribute on an action call that inherits from ModifyChainAttribute")]
     public class ModifyChainAttributeConvention : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Registration/Conventions/StringOutputPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/StringOutputPolicy.cs
@@ -5,7 +5,6 @@ using FubuMVC.Core.Resources.Conneg;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     public class StringOutputPolicy : Policy
     {
         public StringOutputPolicy()
@@ -15,7 +14,6 @@ namespace FubuMVC.Core.Registration.Conventions
         }
     }
 
-    [Policy]
     public class HtmlStringOutputPolicy : Policy
     {
         public HtmlStringOutputPolicy()

--- a/src/FubuMVC.Core/Registration/Conventions/UrlPatternAttributeOnViewModelPolicy.cs
+++ b/src/FubuMVC.Core/Registration/Conventions/UrlPatternAttributeOnViewModelPolicy.cs
@@ -8,7 +8,6 @@ using FubuMVC.Core.Registration.Routes;
 
 namespace FubuMVC.Core.Registration.Conventions
 {
-    [Policy]
     [Title("[UrlPattern] on actionless view models")]
     [Description("Applies a route matching the [UrlPattern] attribute on the Resource Type (View Model) of a BehaviorChain.  Mostly used to add a Route to an 'actionless view'")]
     public class UrlPatternAttributeOnViewModelPolicy : IConfigurationAction

--- a/src/FubuMVC.Core/Registration/Policy.cs
+++ b/src/FubuMVC.Core/Registration/Policy.cs
@@ -12,6 +12,7 @@ namespace FubuMVC.Core.Registration
     /// <summary>
     /// Class used to define BehaviorChain policies and conventions
     /// </summary>
+    [CanBeMultiples]
     public class Policy : IConfigurationAction, DescribesItself
     {
         private readonly IList<IChainModification> _actions = new List<IChainModification>();

--- a/src/FubuMVC.Core/Resources/PathBased/ResourcePathRoutePolicy.cs
+++ b/src/FubuMVC.Core/Resources/PathBased/ResourcePathRoutePolicy.cs
@@ -6,7 +6,6 @@ using FubuMVC.Core.Registration;
 
 namespace FubuMVC.Core.Resources.PathBased
 {
-    [Policy]
     [Title("Builds out the url pattern and route inputs for chains where the Input Type is derived from ResourceHash")]
     public class ResourcePathRoutePolicy : IConfigurationAction
     {

--- a/src/FubuMVC.Core/Security/AttachAuthorizationPolicy.cs
+++ b/src/FubuMVC.Core/Security/AttachAuthorizationPolicy.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 
 namespace FubuMVC.Core.Security
 {
-    [Policy]
     [Title("Attaches the AuthorizationNode to a BehaviorChain if there are any authorization rules on the chain")]
     public class AttachAuthorizationPolicy : IConfigurationAction
     {

--- a/src/FubuMVC.Tests/Registration/Conventions/AsyncContinueWithHandlerConventionTester.cs
+++ b/src/FubuMVC.Tests/Registration/Conventions/AsyncContinueWithHandlerConventionTester.cs
@@ -25,14 +25,6 @@ namespace FubuMVC.Tests.Registration.Conventions
         }
 
         [Test]
-        public void should_be_a_policy()
-        {
-            ConfigGraph.DetermineConfigurationType(new AsyncContinueWithHandlerConvention())
-                .ShouldEqual(ConfigurationType.Policy);
-
-        }
-
-        [Test]
         public void should_attach_async_node_to_actions_that_return_a_task_with_result()
         {
             graph.BehaviorFor<TestControllerForAsync>(x => x.ActionWithInputWithOutputAsync(null))


### PR DESCRIPTION
Removed [Policy] attributes from policies that are registered in DefaultConfigurationPack with their own configuration types via the For(ConfigurationType) syntax in there since that attribute overrides them back to be of CofigurationType.Policy.

added [CanBeMultiples] to Policy to enable more than one anonymous policy
