### PR TITLE
Update the default template to reflect changes in FubuMVC

### DIFF
--- a/fubuTemplates/default/src/FUBUPROJECTNAME/ConfigureFubuMVC.cs
+++ b/fubuTemplates/default/src/FUBUPROJECTNAME/ConfigureFubuMVC.cs
@@ -6,9 +6,6 @@ namespace FUBUPROJECTNAME
     {
         public ConfigureFubuMVC()
         {
-            // This line turns on the basic diagnostics and request tracing
-            IncludeDiagnostics(true);
-
             // All public methods from concrete classes ending in "Controller"
             // in this assembly are assumed to be action methods
             Actions.IncludeClassesSuffixedWithController();
@@ -18,10 +15,6 @@ namespace FUBUPROJECTNAME
                 .IgnoreControllerNamesEntirely()
                 .IgnoreMethodSuffix("Html")
                 .RootAtAssemblyNamespace();
-
-            // Match views to action methods by matching
-            // on model type, view name, and namespace
-            Views.TryToAttachWithDefaultConventions();
         }
     }
 }


### PR DESCRIPTION
I've noticed that whenever I add FubuMVC 0.9.9 + to a project, I have to remove these lines before it will compile (I assume that it's just been overlooked with the structural changes that happened)
