### PR TITLE
New compliance test for SM; helpful for new container support

### DIFF
--- a/src/FubuMVC.StructureMap.Testing/Compliance/ObjectDef_Compliance.cs
+++ b/src/FubuMVC.StructureMap.Testing/Compliance/ObjectDef_Compliance.cs
@@ -42,6 +42,26 @@ namespace FubuMVC.StructureMap.Testing.Compliance
             container.Get<GuyWithService>().Service.ShouldBeOfType<SimpleService>();
         }
 
+		[Test]
+		public void auto_wiring_applies_even_when_another_dependency_is_set_explicitly() {
+			var container = ContainerFacilitySource.New(x => {
+				x.Register(typeof(IService), ObjectDef.ForType<SimpleService>());
+				x.Register(typeof(IThing), ObjectDef.ForType<ThingOne>());
+
+				var def = ObjectDef.ForType<GuyWithServiceAndThing>();
+				def.DependencyByType<IThing>(ObjectDef.ForType<ThingTwo>());
+
+				var highLevelDef = ObjectDef.ForType<HighLevelObject>();
+				highLevelDef.DependencyByType<GuyWithServiceAndThing>(def);
+
+				x.Register(typeof(IHighLevelObject), highLevelDef);
+			});
+
+			var guyWithServiceAndThing = container.Get<GuyWithServiceAndThing>();
+			guyWithServiceAndThing.Service.ShouldBeOfType<SimpleService>(); // auto-wired
+			guyWithServiceAndThing.Thing.ShouldBeOfType<ThingOne>(); // auto-wired, even though explicitly set to ThingTwo for HighLevelObject
+		}
+
         [Test]
         public void ObjectDef_with_one_explicit_dependency_defined_by_type()
         {


### PR DESCRIPTION
I discovered a scenario while working on Autofac support. I added this test to prove that it was failing while all others were near the end (unless it was a fluke). This test should show that the default auto-wiring for an implicit dependency remains valid, even when an explicit dependency for the same service type is in-place for another service definition.

In my case, the explicit dependency was carrying globally, and a simple resolve for GuyWithServiceAndThing was setting Thing to a ThingTwo. That should **only** happen if GuyWithServiceAndThing is activated for an IHighLevelObject resolve.
