### PR TITLE
RouteParameter fix for issue #486

### DIFF
--- a/src/FubuMVC.Core/Registration/Routes/RouteParameter.cs
+++ b/src/FubuMVC.Core/Registration/Routes/RouteParameter.cs
@@ -15,6 +15,7 @@ namespace FubuMVC.Core.Registration.Routes
 
         private readonly Accessor _accessor;
         private readonly Regex _regex;
+        private readonly Regex _regexGreedy;
 
         public RouteParameter(Accessor accessor)
         {
@@ -22,6 +23,7 @@ namespace FubuMVC.Core.Registration.Routes
             accessor.ForAttribute<RouteInputAttribute>(x => DefaultValue = x.DefaultValue);
 
             _regex = new Regex(@"{\*?" + Name + @"(?:\:.*?)?}", RegexOptions.Compiled);
+            _regexGreedy = new Regex(@"{\*" + Name + @"(?:\:.*?)?}", RegexOptions.Compiled);
         }
 
         public string Name { get { return _accessor.Name; } }
@@ -42,7 +44,7 @@ namespace FubuMVC.Core.Registration.Routes
 
         private string substitute(string url, string parameterValue)
         {
-            var encodedValue = encodeParameterValue(parameterValue);
+            var encodedValue = _regexGreedy.IsMatch(url) ? encodeParameterValue(parameterValue) : parameterValue.UrlEncoded();
             return _regex.Replace(url, encodedValue);
         }
 

--- a/src/FubuMVC.Tests/Registration/RouteDefinitionTester.cs
+++ b/src/FubuMVC.Tests/Registration/RouteDefinitionTester.cs
@@ -199,6 +199,18 @@ namespace FubuMVC.Tests.Registration
         }
 
         [Test]
+        public void create_url_with_input_model_and_encoded_variable()
+        {
+            var url = new RouteInput<SampleViewModel>("test/edit/{InPath}");
+            url.AddRouteInput(x => x.InPath);
+
+            url.CreateUrlFromInput(new SampleViewModel
+            {
+                InPath = "abc/def&ghi=jkl"
+            }).ShouldEqual("test/edit/abc%2Fdef%26ghi%3Djkl");
+        }
+
+        [Test]
         public void create_url_with_input_model_and_default_value_for_optional_input()
         {
             var url = new RouteInput<SampleViewModelWithInputs>("test/edit/{OptionalInput}");
@@ -323,6 +335,20 @@ namespace FubuMVC.Tests.Registration
             parameters[x => x.AlsoInPath] = "some text";
 
             url.CreateUrlFromParameters(parameters).ShouldEqual("test/edit/5/some%20text");
+        }
+
+        [Test]
+        public void create_url_with_encoded_variables_in_path_by_parameters()
+        {
+            var url = new RouteInput<SampleViewModel>("test/edit/{InPath}/{AlsoInPath}");
+            url.AddRouteInput(x => x.InPath);
+            url.AddRouteInput(x => x.AlsoInPath);
+
+            var parameters = new RouteParameters<SampleViewModel>();
+            parameters[x => x.InPath] = "5";
+            parameters[x => x.AlsoInPath] = "abc/def&ghi=jkl";
+
+            url.CreateUrlFromParameters(parameters).ShouldEqual("test/edit/5/abc%2Fdef%26ghi%3Djkl");
         }
 
         [Test]

--- a/src/FubuMVC.Tests/Registration/RouteInputTester.cs
+++ b/src/FubuMVC.Tests/Registration/RouteInputTester.cs
@@ -25,6 +25,12 @@ namespace FubuMVC.Tests.Registration
         }
 
         [Test]
+        public void to_query_string_fromwith_encoded_value()
+        {
+            _parameter.ToQueryString(new FakeInput { Code = "abc/def&ghi=jkl" }).ShouldEqual(_parameter.Name + "=abc%2Fdef%26ghi%3Djkl");
+        }
+
+        [Test]
         public void substitute_on_route_parameter()
         {
             var parameters = new RouteParameters<FakeInput>();
@@ -94,6 +100,15 @@ namespace FubuMVC.Tests.Registration
             parameters[x => x.Code] = "something";
 
             _parameter.ToQueryString(parameters).ShouldEqual("Code=something");
+        }
+
+        [Test]
+        public void to_query_string_from_route_parameter_with_an_encoded_value()
+        {
+            var parameters = new RouteParameters<FakeInput>();
+            parameters[x => x.Code] = "abc/def&ghi=jkl";
+
+            _parameter.ToQueryString(parameters).ShouldEqual("Code=abc%2Fdef%26ghi%3Djkl");
         }
     }
 }

--- a/src/FubuMVC.Tests/UrlStringExtensionsTester.cs
+++ b/src/FubuMVC.Tests/UrlStringExtensionsTester.cs
@@ -37,5 +37,11 @@ namespace FubuMVC.Tests
             "http://cnn.com/{script}".ToAbsoluteUrl("http://localhost:5050")
                                      .ShouldEqual("http://cnn.com/{script}");
         }
+
+        [Test]
+        public void url_encoding()
+        {
+            "abc/def&ghi=jkl".UrlEncoded().ShouldEqual("abc%2Fdef%26ghi%3Djkl");
+        }
     }
 }


### PR DESCRIPTION
Fix for issue 486: "UrlFor() doesn't seem to be encoding forward slashes ("/") properly."
https://github.com/DarthFubuMVC/fubumvc/issues/486

RouteParameter updated to handle both greedy routes as well as those that contain "/" that need to be encoded.
