### PR TITLE
Fixes a stack overflow in the StandInCurrentHttpRequest.

### DIFF
--- a/src/FubuMVC.Core/Http/ICurrentHttpRequest.cs
+++ b/src/FubuMVC.Core/Http/ICurrentHttpRequest.cs
@@ -78,7 +78,7 @@ namespace FubuMVC.Core.Http
 
         public string FullUrl()
         {
-            return FullUrl();
+            return StubFullUrl;
         }
 
         public string ToFullUrl(string url)

--- a/src/FubuMVC.Tests/FubuMVC.Tests.csproj
+++ b/src/FubuMVC.Tests/FubuMVC.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Http\Compression\GZipEncodingTester.cs" />
     <Compile Include="Http\Compression\HttpContentEncodersTester.cs" />
     <Compile Include="Http\Compression\HttpContentEncodingFilterTester.cs" />
+    <Compile Include="Http\StandInCurrentHttpRequestTester.cs" />
     <Compile Include="Http\StreamExtensions.cs" />
     <Compile Include="Logging\ExceptionReportTester.cs" />
     <Compile Include="ReflectionExtensionsTester.cs" />

--- a/src/FubuMVC.Tests/Http/CurrentHttpRequestExtensionsTester.cs
+++ b/src/FubuMVC.Tests/Http/CurrentHttpRequestExtensionsTester.cs
@@ -1,7 +1,6 @@
 ﻿using FubuMVC.Core.Http;
-using NUnit.Framework;
-using Rhino.Mocks;
 using FubuTestingSupport;
+using NUnit.Framework;
 
 namespace FubuMVC.Tests.Http
 {

--- a/src/FubuMVC.Tests/Http/StandInCurrentHttpRequestTester.cs
+++ b/src/FubuMVC.Tests/Http/StandInCurrentHttpRequestTester.cs
@@ -1,0 +1,42 @@
+﻿using FubuMVC.Core.Http;
+using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuMVC.Tests.Http
+{
+    [TestFixture]
+    public class StandInCurrentHttpRequestTester
+    {
+        private StandInCurrentHttpRequest theRequest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            theRequest = new StandInCurrentHttpRequest();
+        }
+
+        [Test]
+        public void fullurl_returns_stubfullurl_field()
+        {
+            theRequest.FullUrl().ShouldEqual(theRequest.StubFullUrl);
+        }
+
+        [Test]
+        public void rawurl_returns_therawurl_field()
+        {
+            theRequest.RawUrl().ShouldEqual(theRequest.TheRawUrl);
+        }
+
+        [Test]
+        public void relativeurl_returns_therelativeurl_field()
+        {
+            theRequest.RelativeUrl().ShouldEqual(theRequest.TheRelativeUrl);
+        }
+
+        [Test]
+        public void httpmethod_returns_thehttpmethod_field()
+        {
+            theRequest.HttpMethod().ShouldEqual(theRequest.TheHttpMethod);
+        }
+    }
+}

--- a/src/TestPackage1/.package-manifest
+++ b/src/TestPackage1/.package-manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Role>module</Role>
   <Name>pak1</Name>
   <assembly>TestPackage1</assembly>


### PR DESCRIPTION
Calling FullUrl on StandInCurrentHttpRequest would create a stack overflow.
