### PR TITLE
Add docs for getting started with fubu new

### DIFF
--- a/src/FubuMVC.Docs/3.getting-started.spark
+++ b/src/FubuMVC.Docs/3.getting-started.spark
@@ -10,7 +10,7 @@ Make sure you have the [fubu][fubu] gem installed and open PowerShell in Adminis
 <Info>Administrator Mode is necessary for running the Katana web server</Info>
 
 <pre>
-fubu new MyProjectName --dot-net v4.5 --version VS2013 --options Razor
+fubu new MyProjectName --dot-net v4.5 --version VS2013 --options Spark
 </pre>
 
 <Info>


### PR DESCRIPTION
Here are some notes I took while setting up a new application with the `fubu` gem. I included some options because I had a little bit of friction getting started that I thought other newcomers may face:
- having to restart the shell in Admin mode after Katana failed to start
- not having any view option by default or knowing how to add one
- wondering why it was set to .NET v4.0
- having the solution built by default in 2012, which requires some minor tweaks to work in 2013

---

What do you think about moving this section before the introduction? I may be in the minority, but I heard about FubuMVC through word of mouth. I was already sold on trying to build something with it by the time I was looking for docs -- _getting started_ was the first thing I wanted to find.
