### PR TITLE
package-manifest to include all diagnostics assets

### DIFF
--- a/src/FubuMVC.Diagnostics/.package-manifest
+++ b/src/FubuMVC.Diagnostics/.package-manifest
@@ -3,7 +3,7 @@
   <Role>module</Role>
   <Name>FubuMVC.Diagnostics</Name>
   <assembly>FubuMVC.Diagnostics</assembly>
-  <ContentFileSet Include="*.spark;Shared/*.xml;Content/*.*;*.config">
+  <ContentFileSet Include="*.spark;diagnostics/*.*;Shared/*.xml;Content/*.*;*.config">
     <DeepSearch>true</DeepSearch>
   </ContentFileSet>
 </package>


### PR DESCRIPTION
Currently FubuMVC.Diagnostics doesn't work out of the box due to missing the diagnostics folder and its content.

This pull request includes ALL content.   Is it all required?
