### PR TITLE
File read permission for static files

### DIFF
--- a/src/FubuMVC.Core/Http/Owin/OwinHttpResponse.cs
+++ b/src/FubuMVC.Core/Http/Owin/OwinHttpResponse.cs
@@ -61,7 +61,7 @@ namespace FubuMVC.Core.Http.Owin
             else
             {
                 AppendHeader(HttpResponseHeaders.ContentLength, fileInfo.Length.ToString(CultureInfo.InvariantCulture));
-                using (var fileStream = new FileStream(file, FileMode.Open))
+                using (var fileStream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     Write(stream => fileStream.CopyTo(stream));
                 }


### PR DESCRIPTION
When working with Webpack in development, Webpack retains a write lock
on files. This prevents Fubu from writing that file to an http response
stream due to permission restrictions. This opens the file with read
only access but grants permission for other processing to write to it.
