### PR TITLE
Lock HtmlTags at 2.1.0.185

### DIFF
--- a/ripple.config
+++ b/ripple.config
@@ -22,7 +22,7 @@
     <Dependency Name="Fleck" Version="0.10.0.26" Mode="Fixed" />
     <Dependency Name="FubuCore" Version="2.0.0.287" Mode="Float" />
     <Dependency Name="FubuTestingSupport" Version="2.0.0.287" Mode="Float" />
-    <Dependency Name="HtmlTags" Version="2.1.0.185" Mode="Float" />
+    <Dependency Name="HtmlTags" Version="2.1.0.185" Mode="Fixed" />
     <Dependency Name="Microsoft.AspNet.Razor" Version="2.0.20715.0" Mode="Fixed" />
     <Dependency Name="Microsoft.Net.Http" Version="2.0.20710.0" Mode="Fixed" />
     <Dependency Name="Microsoft.Owin" Version="2.0.0.0" Mode="Fixed" />


### PR DESCRIPTION
HtmlTags 3.0.0.186 removed the generic ITagBuilder interface (and a few other things). This is just a simple fix to get the build functioning again.