### PR TITLE
Implemented user on OwinHttpContext

### DIFF
--- a/src/FubuMVC.Core/Http/Owin/OwinHttpContext.cs
+++ b/src/FubuMVC.Core/Http/Owin/OwinHttpContext.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Net;
+using System.Security.Principal;
 using System.Web;
 
 namespace FubuMVC.Core.Http.Owin
@@ -6,15 +8,24 @@ namespace FubuMVC.Core.Http.Owin
     public class OwinHttpContext : HttpContextBase
     {
         private readonly AspNetHttpRequestAdapter _request;
+        private readonly HttpListenerContext _listenerContext;
 
         public OwinHttpContext(IDictionary<string, object> environment)
         {
             _request = new AspNetHttpRequestAdapter(environment);
+            _listenerContext = environment["System.Net.HttpListenerContext"] as HttpListenerContext;
         }
 
         public override HttpRequestBase Request
         {
             get { return _request; }
         }
+
+        public override IPrincipal User
+        {
+            get { return _listenerContext?.User; }
+        }
+
+
     }
 }

--- a/src/FubuMVC.Core/Security/Authentication/Windows/AspNetWindowsAuthenticationContext.cs
+++ b/src/FubuMVC.Core/Security/Authentication/Windows/AspNetWindowsAuthenticationContext.cs
@@ -15,7 +15,7 @@ namespace FubuMVC.Core.Security.Authentication.Windows
 
         public WindowsPrincipal Current()
         {
-            var identity = _context.User.Identity as WindowsIdentity;
+            var identity = _context.User?.Identity as WindowsIdentity;
             if (identity == null)
             {
                 throw new InvalidOperationException("User identity must be a WindowsIdentity");


### PR DESCRIPTION
In order for the Self hosted HttpContext to work with the
AspNetWindowsAuthenticationContext it needs to implement User. I also
added a null interprolation to the retrieval of User on the
AuthenticationContext in order to show the real error of bad user versus
just a null reference exception.