### PR TITLE
Support use of non-loopback IP in ReplyUri Host Segment for LQ transport

### DIFF
--- a/src/FubuMVC.LightningQueues.Testing/UriExtensionsTester.cs
+++ b/src/FubuMVC.LightningQueues.Testing/UriExtensionsTester.cs
@@ -8,12 +8,29 @@ namespace FubuMVC.LightningQueues.Testing
     
     public class UriExtensionsTester
     {
-        [Fact]
-        public void uses_machinename_over_localhost()
+        private readonly string MachineName = Environment.MachineName.ToLower();
+
+        [Theory]
+        [InlineData("127.0.0.1")]
+        [InlineData("localhost")]
+        public void machineuri_uses_machinename_over_localhost(string host)
         {
-            var testUri = new Uri("lq.tcp://localhost:5150/blah/test?querystring=value");
+            var testUri = new Uri($"lq.tcp://{host}:5150/blah/test?querystring=value");
             var uri = testUri.ToMachineUri();
             uri.ToString().ShouldBe("lq.tcp://{0}:5150/blah/test?querystring=value".ToFormat(Environment.MachineName.ToLower()));
+        }
+
+        [Theory]
+        [InlineData("10.20.30.40", false)]
+        [InlineData("127.0.0.2", false)] //Other IPs in 127.0.0.0/8 aren't recognized.
+        [InlineData("some.name", true)]
+        [InlineData("127.0.0.1", true)]
+        [InlineData("localhost", true)]
+        public void localuri_replaces_hosts_with_machinename_unless_an_ip(string host, bool shouldBeMachineName)
+        {
+            var testUri = new Uri($"lq.tcp://{host}:5150/blah/test?querystring=value");
+            var machineUri = testUri.ToLocalUri();
+            MachineName.Equals(machineUri.Host).ShouldBe(shouldBeMachineName);
         }
     }
 }

--- a/src/FubuMVC.LightningQueues/LightningUri.cs
+++ b/src/FubuMVC.LightningQueues/LightningUri.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace FubuMVC.LightningQueues
 {
@@ -59,7 +60,20 @@ namespace FubuMVC.LightningQueues
 
         public static Uri ToLocalUri(this Uri uri)
         {
+            if (uri.UriContainsNonLocalIpAddress())
+                return uri;
+
             return new UriBuilder(uri) { Host = Environment.MachineName }.Uri;
+        }
+
+        /// <summary>
+        /// Detects if a Uri has a Host segment that is a non-loopback IP address.
+        /// </summary>
+        /// <param name="uri">The Uri.</param>
+        /// <returns>True when the Uri contains a Host segment as an IPv4 Address which is not loopback, otherwise False.</returns>
+        public static bool UriContainsNonLocalIpAddress(this Uri uri)
+        {
+            return (UriHostNameType.IPv4 == uri.HostNameType && !uri.Host.Equals("127.0.0.1"));
         }
     }
 }


### PR DESCRIPTION
This change supports the ability to configure a LQ transport with an address which is using an IP address in the host name. Said address is used when forming a ReplyUri for the channel, making it possible to receive responses to a queue via its IP addres. Previously this was not possible due to a hard replacement of the host name with Environment.MachineName during ReplyUri creation and caching.

This feature is a helpful change to support more self-healing communication in environments where IPs can change quickly but DNS does not replicate as quickly as the communcation is needed.

### Caveat
- Loopback is only recognized as 127.0.0.1 (not others) or localhost
- IPV6 hosts will not be recognized by this feature

### Testing
#### Caveat: The below tests are obtainable via Rider. If using shell or VS, you may encounter an issue with mis-targetting the LMDB.dll for your system processor architecture.
- FubuMVC.Marten.Tests: All fail due to `You need to set the Environment variable marten-testing-database to the connection string for your Postgresql schema`
- FubuMVC.RavenDb.Tests: Two fail, but will succeed if run individually (manually).
- All Others: Passing